### PR TITLE
Fixed plugin-local-storage getter for undefined, boolean and null …

### DIFF
--- a/packages/plugin-local-storage/src/LocalStorage.js
+++ b/packages/plugin-local-storage/src/LocalStorage.js
@@ -78,7 +78,7 @@ class LocalStorage extends Storage {
       item = rawItem;
     }
 
-    if (item && item.value) {
+    if (item && Object.prototype.hasOwnProperty.call(item, 'value')) {
       if (item.expires && Date.now() >= item.expires) {
         this.delete(key);
 

--- a/packages/plugin-local-storage/src/__tests__/LocalStorageSpec.js
+++ b/packages/plugin-local-storage/src/__tests__/LocalStorageSpec.js
@@ -70,6 +70,30 @@ describe('LocalStorageHelper', () => {
       expect(result).toEqual('testValue');
     });
 
+    it('should return correct value boolean', () => {
+      spyOn(localStorage, 'getItem').and.returnValue({ value: false });
+
+      let result = localStorageInstance.get('testName');
+
+      expect(result).toEqual(false);
+    });
+
+    it('should return correct value for undefined', () => {
+      spyOn(localStorage, 'getItem').and.returnValue({ value: undefined });
+
+      let result = localStorageInstance.get('testName');
+
+      expect(result).toEqual(undefined);
+    });
+
+    it('should return correct value for null', () => {
+      spyOn(localStorage, 'getItem').and.returnValue({ value: null });
+
+      let result = localStorageInstance.get('testName');
+
+      expect(result).toEqual(null);
+    });
+
     it('should return undefined and call localStorageInstance.delete method if item is expired', () => {
       spyOn(localStorage, 'getItem').and.returnValue({
         value: 'testValue',


### PR DESCRIPTION
There was an issue when saving `false, undefined, null` values as a scalar directly to local storage. Where when retrieving those values `item && item.value` resulted in `false` and thus `undefined` was always getting returned from `get()` function. This fixes the issue.