### PR TITLE
plugin-rest-client - move logic from Entity to Resource 

### DIFF
--- a/packages/plugin-rest-client/CHANGELOG.md
+++ b/packages/plugin-rest-client/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 2.0.0 - 2020-02-07
+### Changed
+- **BREAKING CHANGE!** - `AbstractEntity` has not dependency on REST API client. All REST API method calls from the `AbstractEntity` was removed.
+### Added
+- Added `AbstractResource` which now contains all rest API call methods that has been extracted from the `AbstractEntity`
+
 ## 1.0.5 - 2019-12-10
 ### Fixed
 - Fixed package build

--- a/packages/plugin-rest-client/README.md
+++ b/packages/plugin-rest-client/README.md
@@ -51,6 +51,8 @@ The Abstract REST client can be configured using the following:
 * `AbstractEntity` - base class for typed approach of identifying REST
   resources. The class also provides various helper method for easier
   manipulation of entities in the REST API.
+ 
+It also provides AbstractResource which helps streamline the process of calling REST API methods on certain resource.
 
 ## Implementing a minimal working REST API client
 
@@ -121,6 +123,20 @@ export default class SimpleRestClient extends AbstractRestClient {
   }
 }
 ```
+### Using `AbstractResource`
+`AbstractResource` provides a way to work with Entities and REST API client more easily. First you need to define your Entities as usual and then in your resource class extend base `AbstractResource` while overriding the `static get entityClass()` getter.
+```javascript
+import { AbstractResource } from '@ima/plugin-rest-client'; 
+import { ArticleEntity } from './Entities/ArticleEntity'; 
+
+class ArticleResource extends AbstractResource {  
+
+    static get entityClass() {
+        return ArticleEntity;
+    }
+
+}
+```
 
 ## Changes in version 1.0.x
 In version 1.0.2 we changed how we handle exports in this npm package. To import components of rest-client in your application
@@ -131,3 +147,7 @@ Also don't forget to change your build.js configuration to just:
 ```javascript
 '@ima/plugin-rest-client'
 ```
+
+## Changes in version 2.x
+Addition of `AbstractResource` which now contains all rest API call methods that has been extracted from the `AbstractEntity`. 
+This has removed dependency on REST API client on the Entity side but also removed all static REST API method calls from the Entity class which has to be handled through defining the resource/service (see above on how to use AbstractResource). Additionally all `AbstractEntity` instance REST API methods have been removed completely.

--- a/packages/plugin-rest-client/src/AbstractEntity.js
+++ b/packages/plugin-rest-client/src/AbstractEntity.js
@@ -1,11 +1,10 @@
 import AbstractDataFieldMapper from './AbstractDataFieldMapper';
-import RestClient from './RestClient';
 import { deepFreeze } from './utils';
 
 /**
  * Symbols for representing the private fields in the entity.
  *
- * @type {Object<string, symbol>}
+ * @type {Object<string, Symbol>}
  */
 const PRIVATE = {
   // static private fields
@@ -39,7 +38,6 @@ export default class AbstractEntity {
   /**
    * Initializes the entity.
    *
-   * @param {RestClient} restClient REST API client.
    * @param {Object<string, *>} data Entity data, which will be directly
    *        assigned to the entity's fields.
    * @param {?AbstractEntity=} parentEntity The entity within which the
@@ -47,26 +45,7 @@ export default class AbstractEntity {
    *        {@code null} if this entity belongs to a top-level resource
    *        without a parent.
    */
-  constructor(restClient, data, parentEntity = null) {
-    if ($Debug) {
-      if (!(restClient instanceof RestClient)) {
-        throw new TypeError(
-          'The rest client must be a RestClient ' +
-            `instance, ${restClient} provided`
-        );
-      }
-    }
-
-    /**
-     * The REST API client to use to communicate with the REST API.
-     *
-     * @type {RestClient}
-     */
-    this[PRIVATE.restClient] = restClient;
-    Object.defineProperty(this, PRIVATE.restClient, {
-      enumerable: false
-    });
-
+  constructor(data, parentEntity = null) {
     /**
      * The entity within which the resource containing this entity is
      * located. Can be set to null if this entity belongs to a top-level
@@ -388,10 +367,9 @@ export default class AbstractEntity {
 
   /**
    * Creates a data field mapper for mapping the property of the specified
-   * name in the raw data to an instance of this entity class. The generated
-   * entity instance will use the rest client of the entity having its data
-   * mapped. The entity having its data mapped will also be set as the parent
-   * entity of the generated entity.
+   * name in the raw data to an instance of this entity class. The entity
+   * having its data mapped will also be set as the parent entity of the
+   * generated entity.
    *
    * @param {?string} dataFieldName The name of the raw data field being
    *        mapped, or {@code null} if it is the same as the name of the
@@ -402,23 +380,10 @@ export default class AbstractEntity {
   static asDataFieldMapper(dataFieldName = null) {
     let entityClass = this;
     return AbstractDataFieldMapper.makeMapper(
-      dataFieldName,
-      (data, parentEntity) =>
-        new entityClass(parentEntity.$restClient, data, parentEntity),
-      entity => entity.$serialize()
+        dataFieldName,
+        (data, parentEntity) => new entityClass(data, parentEntity),
+        entity => entity.$serialize()
     );
-  }
-
-  /**
-   * Returns the REST API client that was used to initialize this entity. The
-   * returned REST API client will also be used in all the dynamic methods of
-   * this entity.
-   *
-   * @return {RestClient} The REST API client that was used to initialize
-   *         this entity.
-   */
-  get $restClient() {
-    return this[PRIVATE.restClient];
   }
 
   /**
@@ -434,365 +399,6 @@ export default class AbstractEntity {
   }
 
   /**
-   * Retrieves the entities within the REST API resource identified by this
-   * entity class according to the provided parameters.
-   *
-   * @param {RestClient} restClient The REST API client using which the
-   *        request should be made.
-   * @param {Object<string, (number|string|(number|string)[])>=} parameters
-   *        The additional parameters to send to the server with the request
-   *        to configure the server's response.
-   * @param {{
-   *            timeout: number=,
-   *            ttl: number=,
-   *            repeatRequest: number=,
-   *            headers: Object<string, string>=,
-   *            cache: boolean=,
-   *            withCredentials: boolean=
-   *        }=} options Request options. See the documentation of the HTTP
-   *        agent for more details.
-   * @param {?AbstractEntity=} parentEntity The parent entity containing the
-   *        resource from which the entities should be listed.
-   * @return {Promise<?(Response|AbstractEntity|AbstractEntity[])>} A promise
-   *         that will resolve to the server's response, or the entity,
-   *         entities or {@code null} constructed from the response body if
-   *         this entity class has the {@code inlineResponseBody} flag set.
-   */
-  static list(restClient, parameters = {}, options = {}, parentEntity = null) {
-    return restClient.list(this, parameters, options, parentEntity);
-  }
-
-  /**
-   * Retrieves the specified entity or entities from the REST API resource
-   * identified by this entity class.
-   *
-   * @param {RestClient} restClient The REST API client using which the
-   *        request should be made.
-   * @param {(number|string|(number|string)[])} id The ID(s) identifying the
-   *        entity or group of entities to retrieve.
-   * @param {Object<string, (number|string|(number|string)[])>=} parameters
-   *        The additional parameters to send to the server with the request
-   *        to configure the server's response.
-   * @param {{
-   *            timeout: number=,
-   *            ttl: number=,
-   *            repeatRequest: number=,
-   *            headers: Object<string, string>=,
-   *            cache: boolean=,
-   *            withCredentials: boolean=
-   *        }=} options Request options. See the documentation of the HTTP
-   *        agent for more details.
-   * @param {?AbstractEntity=} parentEntity The parent entity containing the
-   *        resource from which the entity should be retrieved.
-   * @return {Promise<?(Response|AbstractEntity|AbstractEntity[])>} A promise
-   *         that will resolve to the server's response, or the entity,
-   *         entities or {@code null} constructed from the response body if
-   *         this entity class has the {@code inlineResponseBody} flag set.
-   */
-  static get(
-    restClient,
-    id,
-    parameters = {},
-    options = {},
-    parentEntity = null
-  ) {
-    return restClient.get(this, id, parameters, options, parentEntity);
-  }
-
-  /**
-   * Creates a new entity in the REST API resource identifying by this entity
-   * class using the provided data.
-   *
-   * @param {RestClient} restClient The REST API client using which the
-   *        request should be made.
-   * @param {Object<string, *>} data The entity data. The data should be
-   *        compatible with this entity's structure so that they can be
-   *        directly assigned to the entity, and will be automatically
-   *        serialized before submitting to the server.
-   * @param {Object<string, (number|string|(number|string)[])>=} parameters
-   *        The additional parameters to send to the server with the request
-   *        to configure the server's response.
-   * @param {{
-   *            timeout: number=,
-   *            ttl: number=,
-   *            repeatRequest: number=,
-   *            headers: Object<string, string>=,
-   *            cache: boolean=,
-   *            withCredentials: boolean=
-   *        }=} options Request options. See the documentation of the HTTP
-   *        agent for more details.
-   * @param {?AbstractEntity=} parentEntity The parent entity containing the
-   *        nested resource within which the new entity should be created.
-   * @return {Promise<?(Response|AbstractEntity|AbstractEntity[])>} A promise
-   *         that will resolve to the server's response, or the entity,
-   *         entities or {@code null} constructed from the response body if
-   *         this entity class has the {@code inlineResponseBody} flag set.
-   */
-  static create(
-    restClient,
-    data,
-    parameters = {},
-    options = {},
-    parentEntity = null
-  ) {
-    // We create an entity-like object so that we can serialize the data
-    // and properly create a new entity instance later in the REST API
-    // client.
-    let fakeEntity = Object.create(Object.create(this.prototype));
-    Object.getPrototypeOf(fakeEntity).constructor = this;
-    fakeEntity[PRIVATE.restClient] = restClient;
-    fakeEntity[PRIVATE.parentEntity] = parentEntity;
-    Object.assign(fakeEntity, data);
-
-    let serializedData = fakeEntity.$serialize();
-
-    return restClient.create(
-      this,
-      serializedData,
-      parameters,
-      options,
-      parentEntity
-    );
-  }
-
-  /**
-   * Deletes the specified entity or entities from the REST API resource
-   * identified by this entity class.
-   *
-   * @param {RestClient} restClient The REST API client using which the
-   *        request should be made.
-   * @param {(number|string|(number|string)[])} id The ID(s) identifying the
-   *        entity or group of entities to retrieve.
-   * @param {Object<string, (number|string|(number|string)[])>=} parameters
-   *        The additional parameters to send to the server with the request
-   *        to configure the server's response.
-   * @param {{
-   *            timeout: number=,
-   *            ttl: number=,
-   *            repeatRequest: number=,
-   *            headers: Object<string, string>=,
-   *            cache: boolean=,
-   *            withCredentials: boolean=
-   *        }=} options Request options. See the documentation of the HTTP
-   *        agent for more details.
-   * @param {?AbstractEntity=} parentEntity The parent entity containing the
-   *        resource from which the entity should be deleted.
-   * @return {Promise<?(Response|AbstractEntity|AbstractEntity[])>} A promise
-   *         that will resolve to the server's response, or the entity,
-   *         entities or {@code null} constructed from the response body if
-   *         this entity class has the {@code inlineResponseBody} flag set.
-   */
-  static delete(
-    restClient,
-    id,
-    parameters = {},
-    options = {},
-    parentEntity = null
-  ) {
-    return restClient.delete(this, id, parameters, options, parentEntity);
-  }
-
-  /**
-   * Retrieves the entities within the specified sub-resource of this
-   * entity's resources according to the provided parameters.
-   *
-   * @param {function(
-   *            new: AbstractEntity,
-   *            RestClient,
-   *            Object<string, *>,
-   *            ?AbstractEntity=
-   *        )} subResource The class identifying the resource of the REST API
-   *        resources within this entity.
-   * @param {Object<string, (number|string|(number|string)[])>=} parameters
-   *        The additional parameters to send to the server with the request
-   *        to configure the server's response.
-   * @param {{
-   *            timeout: number=,
-   *            ttl: number=,
-   *            repeatRequest: number=,
-   *            headers: Object<string, string>=,
-   *            cache: boolean=,
-   *            withCredentials: boolean=
-   *        }=} options Request options. See the documentation of the HTTP
-   *        agent for more details.
-   * @return {Promise<?(Response|AbstractEntity|AbstractEntity[])>} A promise
-   *         that will resolve to the server's response, or the entity,
-   *         entities or {@code null} constructed from the response body if
-   *         this entity class has the {@code inlineResponseBody} flag set.
-   */
-  list(subResource, parameters = {}, options = {}) {
-    let client = this[PRIVATE.restClient];
-    return client.list(subResource, parameters, options, this);
-  }
-
-  /**
-   * Retrieves the specified entity/entities from the specified sub-resource
-   * of this entity's resources.
-   *
-   * @param {function(
-   *            new: AbstractEntity,
-   *            RestClient,
-   *            Object<string, *>,
-   *            ?AbstractEntity=
-   *        )} subResource The class identifying the resource of the REST API
-   *        resources within this entity.
-   * @param {(number|string|(number|string)[])} id The ID(s) identifying the
-   *        entity or group of entities to retrieve.
-   * @param {Object<string, (number|string|(number|string)[])>=} parameters
-   *        The additional parameters to send to the server with the request
-   *        to configure the server's response.
-   * @param {{
-   *            timeout: number=,
-   *            ttl: number=,
-   *            repeatRequest: number=,
-   *            headers: Object<string, string>=,
-   *            cache: boolean=,
-   *            withCredentials: boolean=
-   *        }=} options Request options. See the documentation of the HTTP
-   *        agent for more details.
-   * @return {Promise<?(Response|AbstractEntity|AbstractEntity[])>} A promise
-   *         that will resolve to the server's response, or the entity,
-   *         entities or {@code null} constructed from the response body if
-   *         this entity class has the {@code inlineResponseBody} flag set.
-   */
-  get(subResource, id, parameters = {}, options = {}) {
-    let client = this[PRIVATE.restClient];
-    return client.get(subResource, id, parameters, options, this);
-  }
-
-  /**
-   * Patches the state of this entity using the provided data. The method
-   * first patches the state of this entity in the REST API resource, and,
-   * after a successful update, then the method patches the state of this
-   * entity instance.
-   *
-   * @param {Object<string, *>} data The data with which this entity should
-   *        be patched. The data should be compatible with this entity's
-   *        structure so that they can be directly assigned to the entity,
-   *        and will be automatically serialized before submitting to the
-   *        server.
-   * @param {Object<string, (number|string|(number|string)[])>=} parameters
-   *        The additional parameters to send to the server with the request
-   *        to configure the server's response.
-   * @param {{
-   *            timeout: number=,
-   *            ttl: number=,
-   *            repeatRequest: number=,
-   *            headers: Object<string, string>=,
-   *            cache: boolean=,
-   *            withCredentials: boolean=
-   *        }=} options Request options. See the documentation of the HTTP
-   *        agent for more details.
-   * @return {Promise<?(Response|AbstractEntity|AbstractEntity[])>} A promise
-   *         that will resolve to the server's response, or the entity,
-   *         entities or {@code null} constructed from the response body if
-   *         this entity class has the {@code inlineResponseBody} flag set.
-   */
-  patch(data, parameters = {}, options = {}) {
-    let resource = this.constructor;
-    let id = this[resource.idFieldName];
-    let client = this[PRIVATE.restClient];
-    let serializedData = this.$serialize(data);
-    return client
-      .patch(resource, id, serializedData, parameters, options)
-      .then(response => {
-        if (!resource.isImmutable) {
-          Object.assign(this, data);
-        }
-        this.$validatePropTypes();
-        return response;
-      });
-  }
-
-  /**
-   * Replaces this entity in the REST API resource with this entity's current
-   * state.
-   *
-   * @param {Object<string, (number|string|(number|string)[])>=} parameters
-   *        The additional parameters to send to the server with the request
-   *        to configure the server's response.
-   * @param {{
-   *            timeout: number=,
-   *            ttl: number=,
-   *            repeatRequest: number=,
-   *            headers: Object<string, string>=,
-   *            cache: boolean=,
-   *            withCredentials: boolean=
-   *        }=} options Request options. See the documentation of the HTTP
-   *        agent for more details.
-   * @return {Promise<?(Response|AbstractEntity|AbstractEntity[])>} A promise
-   *         that will resolve to the server's response, or the entity,
-   *         entities or {@code null} constructed from the response body if
-   *         this entity class has the {@code inlineResponseBody} flag set.
-   */
-  replace(parameters = {}, options = {}) {
-    let resource = this.constructor;
-    let id = this[resource.idFieldName];
-    let client = this[PRIVATE.restClient];
-    return client.replace(resource, id, this.$serialize(), parameters, options);
-  }
-
-  /**
-   * Creates this entity in the REST API resource it belongs to.
-   *
-   * @param {Object<string, (number|string|(number|string)[])>=} parameters
-   *        The additional parameters to send to the server with the request
-   *        to configure the server's response.
-   * @param {{
-   *            timeout: number=,
-   *            ttl: number=,
-   *            repeatRequest: number=,
-   *            headers: Object<string, string>=,
-   *            cache: boolean=,
-   *            withCredentials: boolean=
-   *        }=} options Request options. See the documentation of the HTTP
-   *        agent for more details.
-   * @return {Promise<?(Response|AbstractEntity|AbstractEntity[])>} A promise
-   *         that will resolve to the server's response, or the entity,
-   *         entities or {@code null} constructed from the response body if
-   *         this entity class has the {@code inlineResponseBody} flag set.
-   */
-  create(parameters = {}, options = {}) {
-    let client = this[PRIVATE.restClient];
-    return client.create(
-      this.constructor,
-      this.$serialize(),
-      parameters,
-      options
-    );
-  }
-
-  /**
-   * Deletes this entity from its resource.
-   *
-   * @param {Object<string, (number|string|(number|string)[])>=} parameters
-   *        The additional parameters to send to the server with the request
-   *        to configure the server's response.
-   * @param {{
-   *            timeout: number=,
-   *            ttl: number=,
-   *            repeatRequest: number=,
-   *            headers: Object<string, string>=,
-   *            cache: boolean=,
-   *            withCredentials: boolean=
-   *        }=} options Request options. See the documentation of the HTTP
-   *        agent for more details.
-   * @return {Promise<?(Response|AbstractEntity|AbstractEntity[])>} A promise
-   *         that will resolve to the server's response, or the entity,
-   *         entities or {@code null} constructed from the response body if
-   *         this entity class has the {@code inlineResponseBody} flag set.
-   */
-  delete(parameters = {}, options = {}) {
-    let id = this[this.constructor.idFieldName];
-    return this.constructor.delete(
-      this[PRIVATE.restClient],
-      id,
-      parameters,
-      options
-    );
-  }
-
-  /**
    * Creates a clone of this entity.
    *
    * @param {boolean=} includingParent The flag specifying whether the parent
@@ -804,10 +410,12 @@ export default class AbstractEntity {
     let data = this.$serialize();
     let entityClass = this.constructor;
     let parentEntity = this[PRIVATE.parentEntity];
+
     if (includingParent && parentEntity) {
       parentEntity = parentEntity.clone(includingParent);
     }
-    return new entityClass(this[PRIVATE.restClient], data, parentEntity);
+
+    return new entityClass(data, parentEntity);
   }
 
   /**
@@ -826,9 +434,9 @@ export default class AbstractEntity {
     let patchData = this.$serialize(statePatch);
     let patchedData = Object.assign({}, data, patchData);
     let entityClass = this.constructor;
-    let restClient = this[PRIVATE.restClient];
     let parentEntity = this[PRIVATE.parentEntity];
-    return new entityClass(restClient, patchedData, parentEntity);
+
+    return new entityClass(patchedData, parentEntity);
   }
 
   /**
@@ -919,8 +527,7 @@ export default class AbstractEntity {
       let rawValue = data[propertyName];
       let mapper = mappings[entityPropertyName];
       if (mapper instanceof Object) {
-        let deserializedValue = mapper.deserialize(rawValue, this);
-        deserializedData[entityPropertyName] = deserializedValue;
+        deserializedData[entityPropertyName] = mapper.deserialize(rawValue, this);
       } else {
         deserializedData[entityPropertyName] = rawValue;
       }

--- a/packages/plugin-rest-client/src/AbstractEntity.js
+++ b/packages/plugin-rest-client/src/AbstractEntity.js
@@ -380,9 +380,9 @@ export default class AbstractEntity {
   static asDataFieldMapper(dataFieldName = null) {
     let entityClass = this;
     return AbstractDataFieldMapper.makeMapper(
-        dataFieldName,
-        (data, parentEntity) => new entityClass(data, parentEntity),
-        entity => entity.$serialize()
+      dataFieldName,
+      (data, parentEntity) => new entityClass(data, parentEntity),
+      entity => entity.$serialize()
     );
   }
 
@@ -527,7 +527,10 @@ export default class AbstractEntity {
       let rawValue = data[propertyName];
       let mapper = mappings[entityPropertyName];
       if (mapper instanceof Object) {
-        deserializedData[entityPropertyName] = mapper.deserialize(rawValue, this);
+        deserializedData[entityPropertyName] = mapper.deserialize(
+          rawValue,
+          this
+        );
       } else {
         deserializedData[entityPropertyName] = rawValue;
       }

--- a/packages/plugin-rest-client/src/AbstractResource.js
+++ b/packages/plugin-rest-client/src/AbstractResource.js
@@ -15,7 +15,7 @@ const PRIVATE = Object.freeze({
  * The base class for creating REST API service classes, used to group REST API methods
  * specified by the REST API client implementation on the given AbstractEntity Class.
  */
-export default class AbstractService {
+export default class AbstractResource {
 	static get $dependencies() {
 		return [RestClient];
 	}
@@ -99,7 +99,7 @@ export default class AbstractService {
 
 	/**
 	 * Retrieves the specified entities from the REST API resource
-	 * identified by the {@link AbstractService.entityClass}.
+	 * identified by the {@link AbstractResource.entityClass}.
 	 *
 	 * @param {Object<string, (number|string|(number|string)[])>=} parameters
 	 *        The additional parameters to send to the server with the request
@@ -131,7 +131,7 @@ export default class AbstractService {
 
 	/**
 	 * Retrieves the specified entity or entities from the REST API resource
-	 * identified by the {@link AbstractService.entityClass}.
+	 * identified by the {@link AbstractResource.entityClass}.
 	 *
 	 * @param {(number|string|(number|string)[])} id The ID(s) identifying the
 	 *        entity or group of entities to retrieve.
@@ -166,7 +166,7 @@ export default class AbstractService {
 
 	/**
 	 * Creates a new entity in the REST API resource identifying by this
-	 * {@link AbstractService.entityClass} class using the provided data.
+	 * {@link AbstractResource.entityClass} class using the provided data.
 	 *
 	 * @param {Object<string, *>} data The entity data. The data should be
 	 *        compatible with this entity's structure so that they can be
@@ -211,7 +211,7 @@ export default class AbstractService {
 
 	/**
 	 * Deletes the specified entity or entities from the REST API resource
-	 * identified by this {@link AbstractService.entityClass} class.
+	 * identified by this {@link AbstractResource.entityClass} class.
 	 *
 	 * @param {(number|string|(number|string)[])} id The ID(s) identifying the
 	 *        entity or group of entities to retrieve.

--- a/packages/plugin-rest-client/src/AbstractResource.js
+++ b/packages/plugin-rest-client/src/AbstractResource.js
@@ -1,0 +1,328 @@
+import RestClient from './RestClient';
+
+/**
+ * Symbols for representing the private fields in the entity.
+ *
+ * @type {Object<string, Symbol>}
+ */
+const PRIVATE = Object.freeze({
+	restClient: Symbol('restClient'),
+	entityClass: Symbol('entityClass'),
+	entityClassConfigured: Symbol('entityClassConfigured')
+});
+
+/**
+ * The base class for creating REST API service classes, used to group REST API methods
+ * specified by the REST API client implementation on the given AbstractEntity Class.
+ */
+export default class AbstractService {
+	static get $dependencies() {
+		return [RestClient];
+	}
+
+	/**
+	 * Initializes the service.
+	 *
+	 * @param {RestClient} restClient REST API client.
+	 */
+	constructor(restClient) {
+		if ($Debug) {
+			if (!(restClient instanceof RestClient)) {
+				throw new TypeError(
+					'The rest client must be a RestClient ' +
+						`instance, ${restClient} provided`
+				);
+			}
+		}
+
+		/**
+		 * The REST API client to use to communicate with the REST API.
+		 *
+		 * @type {RestClient}
+		 */
+		this[PRIVATE.restClient] = restClient;
+		Object.defineProperty(this, PRIVATE.restClient, {
+			enumerable: false
+		});
+	}
+
+	/**
+	 * Returns the REST API client instance that is used in this service class. The
+	 * returned REST API client will also be used in all the dynamic methods of
+	 * this service.
+	 *
+	 * @return {RestClient} The REST API client.
+	 */
+	get $restClient() {
+		return this[PRIVATE.restClient];
+	}
+
+	/**
+	 * Returns entity class identifying the resource of this service, it is also used
+	 * to initialize all data fetched using the appropriate class methods.
+	 *
+	 * @return {?AbstractEntity} Entity class identifying the resource of this service.
+	 */
+	static get entityClass() {
+		if ($Debug) {
+			if (!this[PRIVATE.entityClassConfigured]) {
+				throw new TypeError(
+					'The entityClass field is abstract and must be overridden'
+				);
+			}
+		}
+
+		return this[PRIVATE.entityClass];
+	}
+
+	/**
+	 * This setter is used for compatibility with the Public Class Fields ES
+	 * proposal (at stage 2 at the moment of writing this).
+	 *
+	 * See the related getter for more details about this property.
+	 *
+	 * @param {?AbstractEntity} entityClass Entity class identifying the resource of this service.
+	 */
+	static set entityClass(entityClass) {
+		if ($Debug) {
+			if (this[PRIVATE.entityClassConfigured]) {
+				throw new TypeError('The entityClass property cannot be reconfigured');
+			}
+		}
+
+		this[PRIVATE.entityClass] = entityClass;
+		Object.defineProperty(this, PRIVATE.entityClass, {
+			enumerable: false
+		});
+		this[PRIVATE.entityClassConfigured] = true;
+	}
+
+	/**
+	 * Retrieves the specified entities from the REST API resource
+	 * identified by the {@link AbstractService.entityClass}.
+	 *
+	 * @param {Object<string, (number|string|(number|string)[])>=} parameters
+	 *        The additional parameters to send to the server with the request
+	 *        to configure the server's response.
+	 * @param {{
+	 *            timeout: number=,
+	 *            ttl: number=,
+	 *            repeatRequest: number=,
+	 *            headers: Object<string, string>=,
+	 *            cache: boolean=,
+	 *            withCredentials: boolean=
+	 *        }=} options Request options. See the documentation of the HTTP
+	 *        agent for more details.
+	 * @param {?AbstractEntity=} parentEntity The parent entity containing the
+	 *        resource from which the entities should be listed.
+	 * @return {Promise<?(Response|AbstractEntity|AbstractEntity[])>} A promise
+	 *         that will resolve to the server's response, or the entity,
+	 *         entities or {@code null} constructed from the response body if
+	 *         this entity class has the {@code inlineResponseBody} flag set.
+	 */
+	list(parameters = {}, options = {}, parentEntity = null) {
+		return this[PRIVATE.restClient].list(
+			this.constructor.entityClass,
+			parameters,
+			options,
+			parentEntity
+		);
+	}
+
+	/**
+	 * Retrieves the specified entity or entities from the REST API resource
+	 * identified by the {@link AbstractService.entityClass}.
+	 *
+	 * @param {(number|string|(number|string)[])} id The ID(s) identifying the
+	 *        entity or group of entities to retrieve.
+	 * @param {Object<string, (number|string|(number|string)[])>=} parameters
+	 *        The additional parameters to send to the server with the request
+	 *        to configure the server's response.
+	 * @param {{
+	 *            timeout: number=,
+	 *            ttl: number=,
+	 *            repeatRequest: number=,
+	 *            headers: Object<string, string>=,
+	 *            cache: boolean=,
+	 *            withCredentials: boolean=
+	 *        }=} options Request options. See the documentation of the HTTP
+	 *        agent for more details.
+	 * @param {?AbstractEntity=} parentEntity The parent entity containing the
+	 *        resource from which the entity should be retrieved.
+	 * @return {Promise<?(Response|AbstractEntity|AbstractEntity[])>} A promise
+	 *         that will resolve to the server's response, or the entity,
+	 *         entities or {@code null} constructed from the response body if
+	 *         this entity class has the {@code inlineResponseBody} flag set.
+	 */
+	get(id, parameters = {}, options = {}, parentEntity = null) {
+		return this[PRIVATE.restClient].get(
+			this.constructor.entityClass,
+			id,
+			parameters,
+			options,
+			parentEntity
+		);
+	}
+
+	/**
+	 * Creates a new entity in the REST API resource identifying by this
+	 * {@link AbstractService.entityClass} class using the provided data.
+	 *
+	 * @param {Object<string, *>} data The entity data. The data should be
+	 *        compatible with this entity's structure so that they can be
+	 *        directly assigned to the entity, and will be automatically
+	 *        serialized before submitting to the server.
+	 * @param {Object<string, (number|string|(number|string)[])>=} parameters
+	 *        The additional parameters to send to the server with the request
+	 *        to configure the server's response.
+	 * @param {{
+	 *            timeout: number=,
+	 *            ttl: number=,
+	 *            repeatRequest: number=,
+	 *            headers: Object<string, string>=,
+	 *            cache: boolean=,
+	 *            withCredentials: boolean=
+	 *        }=} options Request options. See the documentation of the HTTP
+	 *        agent for more details.
+	 * @param {?AbstractEntity=} parentEntity The parent entity containing the
+	 *        nested resource within which the new entity should be created.
+	 * @return {Promise<?(Response|AbstractEntity|AbstractEntity[])>} A promise
+	 *         that will resolve to the server's response, or the entity,
+	 *         entities or {@code null} constructed from the response body if
+	 *         this entity class has the {@code inlineResponseBody} flag set.
+	 */
+	create(data, parameters = {}, options = {}, parentEntity = null) {
+		// We create an entity-like object so that we can serialize the data
+		// and properly create a new entity instance later in the REST API client.
+		let fakeEntity = Reflect.construct(this.constructor.entityClass, [
+			data,
+			parentEntity
+		]);
+		let serializedData = fakeEntity.$serialize();
+
+		return this[PRIVATE.restClient].create(
+			this.constructor.entityClass,
+			serializedData,
+			parameters,
+			options,
+			parentEntity
+		);
+	}
+
+	/**
+	 * Deletes the specified entity or entities from the REST API resource
+	 * identified by this {@link AbstractService.entityClass} class.
+	 *
+	 * @param {(number|string|(number|string)[])} id The ID(s) identifying the
+	 *        entity or group of entities to retrieve.
+	 * @param {Object<string, (number|string|(number|string)[])>=} parameters
+	 *        The additional parameters to send to the server with the request
+	 *        to configure the server's response.
+	 * @param {{
+	 *            timeout: number=,
+	 *            ttl: number=,
+	 *            repeatRequest: number=,
+	 *            headers: Object<string, string>=,
+	 *            cache: boolean=,
+	 *            withCredentials: boolean=
+	 *        }=} options Request options. See the documentation of the HTTP
+	 *        agent for more details.
+	 * @param {?AbstractEntity=} parentEntity The parent entity containing the
+	 *        resource from which the entity should be deleted.
+	 * @return {Promise<?(Response|AbstractEntity|AbstractEntity[])>} A promise
+	 *         that will resolve to the server's response, or the entity,
+	 *         entities or {@code null} constructed from the response body if
+	 *         this entity class has the {@code inlineResponseBody} flag set.
+	 */
+	delete(id, parameters = {}, options = {}, parentEntity = null) {
+		return this[PRIVATE.restClient].delete(
+			this.constructor.entityClass,
+			id,
+			parameters,
+			options,
+			parentEntity
+		);
+	}
+
+	/**
+	 * Patches the state of an entity using the provided data. The method
+	 * first patches the state of provided entity in the REST API resource,
+	 * and, after a successful update, the method then patches the state of
+	 * provided entity's instance.
+	 *
+	 * @param {AbstractEntity} entity Instance of the entity to be patched.
+	 * @param {Object<string, *>} data The data with which provided entity
+	 * 		  should be patched. The data should be compatible with provided
+	 * 		  entity's structure so that they can be directly assigned to the
+	 * 		  entity, and will be automatically serialized before submitting
+	 * 		  to the server.
+	 * @param {Object<string, (number|string|(number|string)[])>=} parameters
+	 *        The additional parameters to send to the server with the request
+	 *        to configure the server's response.
+	 * @param {{
+	 *            timeout: number=,
+	 *            ttl: number=,
+	 *            repeatRequest: number=,
+	 *            headers: Object<string, string>=,
+	 *            cache: boolean=,
+	 *            withCredentials: boolean=
+	 *        }=} options Request options. See the documentation of the HTTP
+	 *        agent for more details.
+	 * @return {Promise<?(Response|AbstractEntity|AbstractEntity[])>} A promise
+	 *         that will resolve to the server's response, or the entity,
+	 *         entities or {@code null} constructed from the response body if
+	 *         the provided entity's class has the {@code inlineResponseBody}
+	 *         flag set.
+	 */
+	patch(entity, data, parameters = {}, options = {}) {
+		let resource = entity.constructor;
+		let id = entity[resource.idFieldName];
+
+		return this[PRIVATE.restClient]
+			.patch(resource, id, entity.$serialize(data), parameters, options)
+			.then(response => {
+				if (!resource.isImmutable) {
+					Object.assign(this, data);
+				}
+
+				entity.$validatePropTypes();
+				return response;
+			});
+	}
+
+	/**
+	 * Replaces entity in the REST API resource with the provided entity's current
+	 * state.
+	 *
+	 * @param {AbstractEntity} entity Entity containing state to be replaced.
+	 * @param {Object<string, (number|string|(number|string)[])>=} parameters
+	 *        The additional parameters to send to the server with the request
+	 *        to configure the server's response.
+	 * @param {{
+	 *            timeout: number=,
+	 *            ttl: number=,
+	 *            repeatRequest: number=,
+	 *            headers: Object<string, string>=,
+	 *            cache: boolean=,
+	 *            withCredentials: boolean=
+	 *        }=} options Request options. See the documentation of the HTTP
+	 *        agent for more details.
+	 * @return {Promise<?(Response|AbstractEntity|AbstractEntity[])>} A promise
+	 *         that will resolve to the server's response, or the entity,
+	 *         entities or {@code null} constructed from the response body if
+	 *         the provided entity's class has the {@code inlineResponseBody}
+	 *         flag set.
+	 */
+	replace(entity, parameters = {}, options = {}) {
+		let resource = entity.constructor;
+		let id = entity[resource.idFieldName];
+
+		return this[PRIVATE.restClient].replace(
+			resource,
+			id,
+			entity.$serialize(),
+			parameters,
+			options
+		);
+	}
+}

--- a/packages/plugin-rest-client/src/AbstractResource.js
+++ b/packages/plugin-rest-client/src/AbstractResource.js
@@ -6,9 +6,9 @@ import RestClient from './RestClient';
  * @type {Object<string, Symbol>}
  */
 const PRIVATE = Object.freeze({
-	restClient: Symbol('restClient'),
-	entityClass: Symbol('entityClass'),
-	entityClassConfigured: Symbol('entityClassConfigured')
+  restClient: Symbol('restClient'),
+  entityClass: Symbol('entityClass'),
+  entityClassConfigured: Symbol('entityClassConfigured')
 });
 
 /**
@@ -16,313 +16,313 @@ const PRIVATE = Object.freeze({
  * specified by the REST API client implementation on the given AbstractEntity Class.
  */
 export default class AbstractResource {
-	static get $dependencies() {
-		return [RestClient];
-	}
+  static get $dependencies() {
+    return [RestClient];
+  }
 
-	/**
-	 * Initializes the service.
-	 *
-	 * @param {RestClient} restClient REST API client.
-	 */
-	constructor(restClient) {
-		if ($Debug) {
-			if (!(restClient instanceof RestClient)) {
-				throw new TypeError(
-					'The rest client must be a RestClient ' +
-						`instance, ${restClient} provided`
-				);
-			}
-		}
+  /**
+   * Initializes the service.
+   *
+   * @param {RestClient} restClient REST API client.
+   */
+  constructor(restClient) {
+    if ($Debug) {
+      if (!(restClient instanceof RestClient)) {
+        throw new TypeError(
+          'The rest client must be a RestClient ' +
+            `instance, ${restClient} provided`
+        );
+      }
+    }
 
-		/**
-		 * The REST API client to use to communicate with the REST API.
-		 *
-		 * @type {RestClient}
-		 */
-		this[PRIVATE.restClient] = restClient;
-		Object.defineProperty(this, PRIVATE.restClient, {
-			enumerable: false
-		});
-	}
+    /**
+     * The REST API client to use to communicate with the REST API.
+     *
+     * @type {RestClient}
+     */
+    this[PRIVATE.restClient] = restClient;
+    Object.defineProperty(this, PRIVATE.restClient, {
+      enumerable: false
+    });
+  }
 
-	/**
-	 * Returns the REST API client instance that is used in this service class. The
-	 * returned REST API client will also be used in all the dynamic methods of
-	 * this service.
-	 *
-	 * @return {RestClient} The REST API client.
-	 */
-	get $restClient() {
-		return this[PRIVATE.restClient];
-	}
+  /**
+   * Returns the REST API client instance that is used in this service class. The
+   * returned REST API client will also be used in all the dynamic methods of
+   * this service.
+   *
+   * @return {RestClient} The REST API client.
+   */
+  get $restClient() {
+    return this[PRIVATE.restClient];
+  }
 
-	/**
-	 * Returns entity class identifying the resource of this service, it is also used
-	 * to initialize all data fetched using the appropriate class methods.
-	 *
-	 * @return {?AbstractEntity} Entity class identifying the resource of this service.
-	 */
-	static get entityClass() {
-		if ($Debug) {
-			if (!this[PRIVATE.entityClassConfigured]) {
-				throw new TypeError(
-					'The entityClass field is abstract and must be overridden'
-				);
-			}
-		}
+  /**
+   * Returns entity class identifying the resource of this service, it is also used
+   * to initialize all data fetched using the appropriate class methods.
+   *
+   * @return {?AbstractEntity} Entity class identifying the resource of this service.
+   */
+  static get entityClass() {
+    if ($Debug) {
+      if (!this[PRIVATE.entityClassConfigured]) {
+        throw new TypeError(
+          'The entityClass field is abstract and must be overridden'
+        );
+      }
+    }
 
-		return this[PRIVATE.entityClass];
-	}
+    return this[PRIVATE.entityClass];
+  }
 
-	/**
-	 * This setter is used for compatibility with the Public Class Fields ES
-	 * proposal (at stage 2 at the moment of writing this).
-	 *
-	 * See the related getter for more details about this property.
-	 *
-	 * @param {?AbstractEntity} entityClass Entity class identifying the resource of this service.
-	 */
-	static set entityClass(entityClass) {
-		if ($Debug) {
-			if (this[PRIVATE.entityClassConfigured]) {
-				throw new TypeError('The entityClass property cannot be reconfigured');
-			}
-		}
+  /**
+   * This setter is used for compatibility with the Public Class Fields ES
+   * proposal (at stage 2 at the moment of writing this).
+   *
+   * See the related getter for more details about this property.
+   *
+   * @param {?AbstractEntity} entityClass Entity class identifying the resource of this service.
+   */
+  static set entityClass(entityClass) {
+    if ($Debug) {
+      if (this[PRIVATE.entityClassConfigured]) {
+        throw new TypeError('The entityClass property cannot be reconfigured');
+      }
+    }
 
-		this[PRIVATE.entityClass] = entityClass;
-		Object.defineProperty(this, PRIVATE.entityClass, {
-			enumerable: false
-		});
-		this[PRIVATE.entityClassConfigured] = true;
-	}
+    this[PRIVATE.entityClass] = entityClass;
+    Object.defineProperty(this, PRIVATE.entityClass, {
+      enumerable: false
+    });
+    this[PRIVATE.entityClassConfigured] = true;
+  }
 
-	/**
-	 * Retrieves the specified entities from the REST API resource
-	 * identified by the {@link AbstractResource.entityClass}.
-	 *
-	 * @param {Object<string, (number|string|(number|string)[])>=} parameters
-	 *        The additional parameters to send to the server with the request
-	 *        to configure the server's response.
-	 * @param {{
-	 *            timeout: number=,
-	 *            ttl: number=,
-	 *            repeatRequest: number=,
-	 *            headers: Object<string, string>=,
-	 *            cache: boolean=,
-	 *            withCredentials: boolean=
-	 *        }=} options Request options. See the documentation of the HTTP
-	 *        agent for more details.
-	 * @param {?AbstractEntity=} parentEntity The parent entity containing the
-	 *        resource from which the entities should be listed.
-	 * @return {Promise<?(Response|AbstractEntity|AbstractEntity[])>} A promise
-	 *         that will resolve to the server's response, or the entity,
-	 *         entities or {@code null} constructed from the response body if
-	 *         this entity class has the {@code inlineResponseBody} flag set.
-	 */
-	list(parameters = {}, options = {}, parentEntity = null) {
-		return this[PRIVATE.restClient].list(
-			this.constructor.entityClass,
-			parameters,
-			options,
-			parentEntity
-		);
-	}
+  /**
+   * Retrieves the specified entities from the REST API resource
+   * identified by the {@link AbstractResource.entityClass}.
+   *
+   * @param {Object<string, (number|string|(number|string)[])>=} parameters
+   *        The additional parameters to send to the server with the request
+   *        to configure the server's response.
+   * @param {{
+   *            timeout: number=,
+   *            ttl: number=,
+   *            repeatRequest: number=,
+   *            headers: Object<string, string>=,
+   *            cache: boolean=,
+   *            withCredentials: boolean=
+   *        }=} options Request options. See the documentation of the HTTP
+   *        agent for more details.
+   * @param {?AbstractEntity=} parentEntity The parent entity containing the
+   *        resource from which the entities should be listed.
+   * @return {Promise<?(Response|AbstractEntity|AbstractEntity[])>} A promise
+   *         that will resolve to the server's response, or the entity,
+   *         entities or {@code null} constructed from the response body if
+   *         this entity class has the {@code inlineResponseBody} flag set.
+   */
+  list(parameters = {}, options = {}, parentEntity = null) {
+    return this[PRIVATE.restClient].list(
+      this.constructor.entityClass,
+      parameters,
+      options,
+      parentEntity
+    );
+  }
 
-	/**
-	 * Retrieves the specified entity or entities from the REST API resource
-	 * identified by the {@link AbstractResource.entityClass}.
-	 *
-	 * @param {(number|string|(number|string)[])} id The ID(s) identifying the
-	 *        entity or group of entities to retrieve.
-	 * @param {Object<string, (number|string|(number|string)[])>=} parameters
-	 *        The additional parameters to send to the server with the request
-	 *        to configure the server's response.
-	 * @param {{
-	 *            timeout: number=,
-	 *            ttl: number=,
-	 *            repeatRequest: number=,
-	 *            headers: Object<string, string>=,
-	 *            cache: boolean=,
-	 *            withCredentials: boolean=
-	 *        }=} options Request options. See the documentation of the HTTP
-	 *        agent for more details.
-	 * @param {?AbstractEntity=} parentEntity The parent entity containing the
-	 *        resource from which the entity should be retrieved.
-	 * @return {Promise<?(Response|AbstractEntity|AbstractEntity[])>} A promise
-	 *         that will resolve to the server's response, or the entity,
-	 *         entities or {@code null} constructed from the response body if
-	 *         this entity class has the {@code inlineResponseBody} flag set.
-	 */
-	get(id, parameters = {}, options = {}, parentEntity = null) {
-		return this[PRIVATE.restClient].get(
-			this.constructor.entityClass,
-			id,
-			parameters,
-			options,
-			parentEntity
-		);
-	}
+  /**
+   * Retrieves the specified entity or entities from the REST API resource
+   * identified by the {@link AbstractResource.entityClass}.
+   *
+   * @param {(number|string|(number|string)[])} id The ID(s) identifying the
+   *        entity or group of entities to retrieve.
+   * @param {Object<string, (number|string|(number|string)[])>=} parameters
+   *        The additional parameters to send to the server with the request
+   *        to configure the server's response.
+   * @param {{
+   *            timeout: number=,
+   *            ttl: number=,
+   *            repeatRequest: number=,
+   *            headers: Object<string, string>=,
+   *            cache: boolean=,
+   *            withCredentials: boolean=
+   *        }=} options Request options. See the documentation of the HTTP
+   *        agent for more details.
+   * @param {?AbstractEntity=} parentEntity The parent entity containing the
+   *        resource from which the entity should be retrieved.
+   * @return {Promise<?(Response|AbstractEntity|AbstractEntity[])>} A promise
+   *         that will resolve to the server's response, or the entity,
+   *         entities or {@code null} constructed from the response body if
+   *         this entity class has the {@code inlineResponseBody} flag set.
+   */
+  get(id, parameters = {}, options = {}, parentEntity = null) {
+    return this[PRIVATE.restClient].get(
+      this.constructor.entityClass,
+      id,
+      parameters,
+      options,
+      parentEntity
+    );
+  }
 
-	/**
-	 * Creates a new entity in the REST API resource identifying by this
-	 * {@link AbstractResource.entityClass} class using the provided data.
-	 *
-	 * @param {Object<string, *>} data The entity data. The data should be
-	 *        compatible with this entity's structure so that they can be
-	 *        directly assigned to the entity, and will be automatically
-	 *        serialized before submitting to the server.
-	 * @param {Object<string, (number|string|(number|string)[])>=} parameters
-	 *        The additional parameters to send to the server with the request
-	 *        to configure the server's response.
-	 * @param {{
-	 *            timeout: number=,
-	 *            ttl: number=,
-	 *            repeatRequest: number=,
-	 *            headers: Object<string, string>=,
-	 *            cache: boolean=,
-	 *            withCredentials: boolean=
-	 *        }=} options Request options. See the documentation of the HTTP
-	 *        agent for more details.
-	 * @param {?AbstractEntity=} parentEntity The parent entity containing the
-	 *        nested resource within which the new entity should be created.
-	 * @return {Promise<?(Response|AbstractEntity|AbstractEntity[])>} A promise
-	 *         that will resolve to the server's response, or the entity,
-	 *         entities or {@code null} constructed from the response body if
-	 *         this entity class has the {@code inlineResponseBody} flag set.
-	 */
-	create(data, parameters = {}, options = {}, parentEntity = null) {
-		// We create an entity-like object so that we can serialize the data
-		// and properly create a new entity instance later in the REST API client.
-		let fakeEntity = Reflect.construct(this.constructor.entityClass, [
-			data,
-			parentEntity
-		]);
-		let serializedData = fakeEntity.$serialize();
+  /**
+   * Creates a new entity in the REST API resource identifying by this
+   * {@link AbstractResource.entityClass} class using the provided data.
+   *
+   * @param {Object<string, *>} data The entity data. The data should be
+   *        compatible with this entity's structure so that they can be
+   *        directly assigned to the entity, and will be automatically
+   *        serialized before submitting to the server.
+   * @param {Object<string, (number|string|(number|string)[])>=} parameters
+   *        The additional parameters to send to the server with the request
+   *        to configure the server's response.
+   * @param {{
+   *            timeout: number=,
+   *            ttl: number=,
+   *            repeatRequest: number=,
+   *            headers: Object<string, string>=,
+   *            cache: boolean=,
+   *            withCredentials: boolean=
+   *        }=} options Request options. See the documentation of the HTTP
+   *        agent for more details.
+   * @param {?AbstractEntity=} parentEntity The parent entity containing the
+   *        nested resource within which the new entity should be created.
+   * @return {Promise<?(Response|AbstractEntity|AbstractEntity[])>} A promise
+   *         that will resolve to the server's response, or the entity,
+   *         entities or {@code null} constructed from the response body if
+   *         this entity class has the {@code inlineResponseBody} flag set.
+   */
+  create(data, parameters = {}, options = {}, parentEntity = null) {
+    // We create an entity-like object so that we can serialize the data
+    // and properly create a new entity instance later in the REST API client.
+    let fakeEntity = Reflect.construct(this.constructor.entityClass, [
+      data,
+      parentEntity
+    ]);
+    let serializedData = fakeEntity.$serialize();
 
-		return this[PRIVATE.restClient].create(
-			this.constructor.entityClass,
-			serializedData,
-			parameters,
-			options,
-			parentEntity
-		);
-	}
+    return this[PRIVATE.restClient].create(
+      this.constructor.entityClass,
+      serializedData,
+      parameters,
+      options,
+      parentEntity
+    );
+  }
 
-	/**
-	 * Deletes the specified entity or entities from the REST API resource
-	 * identified by this {@link AbstractResource.entityClass} class.
-	 *
-	 * @param {(number|string|(number|string)[])} id The ID(s) identifying the
-	 *        entity or group of entities to retrieve.
-	 * @param {Object<string, (number|string|(number|string)[])>=} parameters
-	 *        The additional parameters to send to the server with the request
-	 *        to configure the server's response.
-	 * @param {{
-	 *            timeout: number=,
-	 *            ttl: number=,
-	 *            repeatRequest: number=,
-	 *            headers: Object<string, string>=,
-	 *            cache: boolean=,
-	 *            withCredentials: boolean=
-	 *        }=} options Request options. See the documentation of the HTTP
-	 *        agent for more details.
-	 * @param {?AbstractEntity=} parentEntity The parent entity containing the
-	 *        resource from which the entity should be deleted.
-	 * @return {Promise<?(Response|AbstractEntity|AbstractEntity[])>} A promise
-	 *         that will resolve to the server's response, or the entity,
-	 *         entities or {@code null} constructed from the response body if
-	 *         this entity class has the {@code inlineResponseBody} flag set.
-	 */
-	delete(id, parameters = {}, options = {}, parentEntity = null) {
-		return this[PRIVATE.restClient].delete(
-			this.constructor.entityClass,
-			id,
-			parameters,
-			options,
-			parentEntity
-		);
-	}
+  /**
+   * Deletes the specified entity or entities from the REST API resource
+   * identified by this {@link AbstractResource.entityClass} class.
+   *
+   * @param {(number|string|(number|string)[])} id The ID(s) identifying the
+   *        entity or group of entities to retrieve.
+   * @param {Object<string, (number|string|(number|string)[])>=} parameters
+   *        The additional parameters to send to the server with the request
+   *        to configure the server's response.
+   * @param {{
+   *            timeout: number=,
+   *            ttl: number=,
+   *            repeatRequest: number=,
+   *            headers: Object<string, string>=,
+   *            cache: boolean=,
+   *            withCredentials: boolean=
+   *        }=} options Request options. See the documentation of the HTTP
+   *        agent for more details.
+   * @param {?AbstractEntity=} parentEntity The parent entity containing the
+   *        resource from which the entity should be deleted.
+   * @return {Promise<?(Response|AbstractEntity|AbstractEntity[])>} A promise
+   *         that will resolve to the server's response, or the entity,
+   *         entities or {@code null} constructed from the response body if
+   *         this entity class has the {@code inlineResponseBody} flag set.
+   */
+  delete(id, parameters = {}, options = {}, parentEntity = null) {
+    return this[PRIVATE.restClient].delete(
+      this.constructor.entityClass,
+      id,
+      parameters,
+      options,
+      parentEntity
+    );
+  }
 
-	/**
-	 * Patches the state of an entity using the provided data. The method
-	 * first patches the state of provided entity in the REST API resource,
-	 * and, after a successful update, the method then patches the state of
-	 * provided entity's instance.
-	 *
-	 * @param {AbstractEntity} entity Instance of the entity to be patched.
-	 * @param {Object<string, *>} data The data with which provided entity
-	 * 		  should be patched. The data should be compatible with provided
-	 * 		  entity's structure so that they can be directly assigned to the
-	 * 		  entity, and will be automatically serialized before submitting
-	 * 		  to the server.
-	 * @param {Object<string, (number|string|(number|string)[])>=} parameters
-	 *        The additional parameters to send to the server with the request
-	 *        to configure the server's response.
-	 * @param {{
-	 *            timeout: number=,
-	 *            ttl: number=,
-	 *            repeatRequest: number=,
-	 *            headers: Object<string, string>=,
-	 *            cache: boolean=,
-	 *            withCredentials: boolean=
-	 *        }=} options Request options. See the documentation of the HTTP
-	 *        agent for more details.
-	 * @return {Promise<?(Response|AbstractEntity|AbstractEntity[])>} A promise
-	 *         that will resolve to the server's response, or the entity,
-	 *         entities or {@code null} constructed from the response body if
-	 *         the provided entity's class has the {@code inlineResponseBody}
-	 *         flag set.
-	 */
-	patch(entity, data, parameters = {}, options = {}) {
-		let resource = entity.constructor;
-		let id = entity[resource.idFieldName];
+  /**
+   * Patches the state of an entity using the provided data. The method
+   * first patches the state of provided entity in the REST API resource,
+   * and, after a successful update, the method then patches the state of
+   * provided entity's instance.
+   *
+   * @param {AbstractEntity} entity Instance of the entity to be patched.
+   * @param {Object<string, *>} data The data with which provided entity
+   * 		  should be patched. The data should be compatible with provided
+   * 		  entity's structure so that they can be directly assigned to the
+   * 		  entity, and will be automatically serialized before submitting
+   * 		  to the server.
+   * @param {Object<string, (number|string|(number|string)[])>=} parameters
+   *        The additional parameters to send to the server with the request
+   *        to configure the server's response.
+   * @param {{
+   *            timeout: number=,
+   *            ttl: number=,
+   *            repeatRequest: number=,
+   *            headers: Object<string, string>=,
+   *            cache: boolean=,
+   *            withCredentials: boolean=
+   *        }=} options Request options. See the documentation of the HTTP
+   *        agent for more details.
+   * @return {Promise<?(Response|AbstractEntity|AbstractEntity[])>} A promise
+   *         that will resolve to the server's response, or the entity,
+   *         entities or {@code null} constructed from the response body if
+   *         the provided entity's class has the {@code inlineResponseBody}
+   *         flag set.
+   */
+  patch(entity, data, parameters = {}, options = {}) {
+    let resource = entity.constructor;
+    let id = entity[resource.idFieldName];
 
-		return this[PRIVATE.restClient]
-			.patch(resource, id, entity.$serialize(data), parameters, options)
-			.then(response => {
-				if (!resource.isImmutable) {
-					Object.assign(this, data);
-				}
+    return this[PRIVATE.restClient]
+      .patch(resource, id, entity.$serialize(data), parameters, options)
+      .then(response => {
+        if (!resource.isImmutable) {
+          Object.assign(this, data);
+        }
 
-				entity.$validatePropTypes();
-				return response;
-			});
-	}
+        entity.$validatePropTypes();
+        return response;
+      });
+  }
 
-	/**
-	 * Replaces entity in the REST API resource with the provided entity's current
-	 * state.
-	 *
-	 * @param {AbstractEntity} entity Entity containing state to be replaced.
-	 * @param {Object<string, (number|string|(number|string)[])>=} parameters
-	 *        The additional parameters to send to the server with the request
-	 *        to configure the server's response.
-	 * @param {{
-	 *            timeout: number=,
-	 *            ttl: number=,
-	 *            repeatRequest: number=,
-	 *            headers: Object<string, string>=,
-	 *            cache: boolean=,
-	 *            withCredentials: boolean=
-	 *        }=} options Request options. See the documentation of the HTTP
-	 *        agent for more details.
-	 * @return {Promise<?(Response|AbstractEntity|AbstractEntity[])>} A promise
-	 *         that will resolve to the server's response, or the entity,
-	 *         entities or {@code null} constructed from the response body if
-	 *         the provided entity's class has the {@code inlineResponseBody}
-	 *         flag set.
-	 */
-	replace(entity, parameters = {}, options = {}) {
-		let resource = entity.constructor;
-		let id = entity[resource.idFieldName];
+  /**
+   * Replaces entity in the REST API resource with the provided entity's current
+   * state.
+   *
+   * @param {AbstractEntity} entity Entity containing state to be replaced.
+   * @param {Object<string, (number|string|(number|string)[])>=} parameters
+   *        The additional parameters to send to the server with the request
+   *        to configure the server's response.
+   * @param {{
+   *            timeout: number=,
+   *            ttl: number=,
+   *            repeatRequest: number=,
+   *            headers: Object<string, string>=,
+   *            cache: boolean=,
+   *            withCredentials: boolean=
+   *        }=} options Request options. See the documentation of the HTTP
+   *        agent for more details.
+   * @return {Promise<?(Response|AbstractEntity|AbstractEntity[])>} A promise
+   *         that will resolve to the server's response, or the entity,
+   *         entities or {@code null} constructed from the response body if
+   *         the provided entity's class has the {@code inlineResponseBody}
+   *         flag set.
+   */
+  replace(entity, parameters = {}, options = {}) {
+    let resource = entity.constructor;
+    let id = entity[resource.idFieldName];
 
-		return this[PRIVATE.restClient].replace(
-			resource,
-			id,
-			entity.$serialize(),
-			parameters,
-			options
-		);
-	}
+    return this[PRIVATE.restClient].replace(
+      resource,
+      id,
+      entity.$serialize(),
+      parameters,
+      options
+    );
+  }
 }

--- a/packages/plugin-rest-client/src/AbstractRestClient.js
+++ b/packages/plugin-rest-client/src/AbstractRestClient.js
@@ -429,9 +429,7 @@ export default class AbstractRestClient extends RestClient {
     }
 
     if (body instanceof Array) {
-      body = body.map(
-        entityData => new resource(entityData, parentEntity)
-      );
+      body = body.map(entityData => new resource(entityData, parentEntity));
     } else if (body) {
       body = new resource(body, parentEntity);
     } else {

--- a/packages/plugin-rest-client/src/AbstractRestClient.js
+++ b/packages/plugin-rest-client/src/AbstractRestClient.js
@@ -430,10 +430,10 @@ export default class AbstractRestClient extends RestClient {
 
     if (body instanceof Array) {
       body = body.map(
-        entityData => new resource(this, entityData, parentEntity)
+        entityData => new resource(entityData, parentEntity)
       );
     } else if (body) {
-      body = new resource(this, body, parentEntity);
+      body = new resource(body, parentEntity);
     } else {
       body = null;
     }

--- a/packages/plugin-rest-client/src/__tests__/AbstractEntitySpec.js
+++ b/packages/plugin-rest-client/src/__tests__/AbstractEntitySpec.js
@@ -379,22 +379,6 @@ describe('AbstractEntity', () => {
       testStaticProperty(AbstractEntity, 'isImmutable', false, false, true);
     });
 
-    it('should be possible to configure idParameterName exactly once', () => {
-      testStaticProperty(
-        AbstractEntity,
-        'dataFieldMapping',
-        {},
-        false,
-        'itemId'
-      );
-    });
-
-    it('should be possible to configure embeds exactly once', () => {
-      testStaticProperty(AbstractEntity, 'isImmutable', false, false, {
-        id: '_id'
-      });
-    });
-
     it(
       'should have all its private symbol properties marked as ' +
         'non-enumerable',

--- a/packages/plugin-rest-client/src/__tests__/AbstractEntitySpec.js
+++ b/packages/plugin-rest-client/src/__tests__/AbstractEntitySpec.js
@@ -1,6 +1,6 @@
 import AbstractDataFieldMapper from '../AbstractDataFieldMapper';
 import AbstractEntity from '../AbstractEntity';
-import AbstractRestClient from '../AbstractRestClient';
+import { testStaticProperty } from './RestClientTestUtils';
 
 describe('AbstractEntity', () => {
   class Entity extends AbstractEntity {
@@ -17,98 +17,19 @@ describe('AbstractEntity', () => {
     }
   }
 
-  let restResult;
-  let calledClientMethods;
-  let parametersToPass;
-  let passedParameters;
-  let restClient;
-  let restClientCallbacks;
+  it('should support a parent entity', () => {
+    let parentEntity = new Entity({ id: 1 });
+    let entity = new Entity({ id: 2 }, parentEntity);
 
-  class RestClient extends AbstractRestClient {
-    list(resource, parameters = {}) {
-      calledClientMethods.list = true;
-      passedParameters = parameters;
-      return Promise.resolve(restResult);
-    }
-
-    get(resource, id, parameters = {}) {
-      calledClientMethods.get = true;
-      passedParameters = parameters;
-      return Promise.resolve(restResult);
-    }
-
-    patch(resource, id, data, parameters = {}) {
-      calledClientMethods.patch = true;
-      passedParameters = parameters;
-
-      if (restClientCallbacks.patch) {
-        restClientCallbacks.patch(data);
-      }
-      return Promise.resolve(restResult);
-    }
-
-    replace(resource, id, data, parameters = {}) {
-      calledClientMethods.replace = true;
-      passedParameters = parameters;
-
-      if (restClientCallbacks.replace) {
-        restClientCallbacks.replace(data);
-      }
-      return Promise.resolve(restResult);
-    }
-
-    create(resource, data, parameters = {}) {
-      calledClientMethods.create = true;
-      passedParameters = parameters;
-
-      if (restClientCallbacks.create) {
-        restClientCallbacks.create(data);
-      }
-      return Promise.resolve(restResult);
-    }
-
-    delete(resource, id, parameters = {}) {
-      calledClientMethods.delete = true;
-      passedParameters = parameters;
-
-      return Promise.resolve(restResult);
-    }
-  }
-
-  beforeEach(() => {
-    restResult = null;
-    calledClientMethods = {
-      list: false,
-      get: false,
-      patch: false,
-      replace: false,
-      create: false,
-      delete: false
-    };
-    restClientCallbacks = {
-      create: null,
-      patch: null,
-      replace: null
-    };
-    restClient = new RestClient(null, null, null, [], []);
-    parametersToPass = { key: 'value' };
-    passedParameters = undefined;
-  });
-
-  it('should reject invalid rest client constructor argument', () => {
-    expect(() => {
-      new Entity(null, {});
-    }).toThrowError(TypeError);
-
-    new Entity(restClient, {});
+    expect(entity.$parentEntity).toBe(parentEntity);
   });
 
   it('should assign data to its instance', () => {
-    let template = new Entity(restClient, {});
+    let template = new Entity({});
     template.id = 12;
     template.test = true;
     expect(
-      new Entity(restClient, {
+      new Entity({
         id: 12,
         test: true
       })
@@ -118,187 +39,20 @@ describe('AbstractEntity', () => {
   it('should keep reference to its parent entity', () => {
     expect(
       new Entity(
-        restClient,
         {},
-        new Entity(restClient, {
+        new Entity({
           id: 'yup'
         })
       ).$parentEntity
     ).toEqual(
-      new Entity(restClient, {
+      new Entity({
         id: 'yup'
       })
     );
   });
 
-  it('should keep reference to the REST API client', () => {
-    expect(new Entity(restClient, {}).$restClient).toBe(restClient);
-  });
-
-  it('should allow listing of entities', done => {
-    restResult = 123;
-    return Entity.list(restClient, parametersToPass)
-      .then(response => {
-        expect(response).toBe(restResult);
-        expect(calledClientMethods.list).toBeTruthy();
-        expect(passedParameters).toEqual(parametersToPass);
-        done();
-      })
-      .catch(error => {
-        fail(error.stack);
-        done();
-      });
-  });
-
-  it('should allow retrieving a single entity', done => {
-    restResult = 234;
-    return Entity.get(restClient, 1, parametersToPass)
-      .then(response => {
-        expect(response).toBe(restResult);
-        expect(calledClientMethods.get).toBeTruthy();
-        expect(passedParameters).toEqual(parametersToPass);
-        done();
-      })
-      .catch(error => {
-        fail(error.stack);
-        done();
-      });
-  });
-
-  it('should allow creating new entities', done => {
-    restResult = 345;
-    return Entity.create(restClient, {}, parametersToPass)
-      .then(response => {
-        expect(response).toBe(restResult);
-        expect(calledClientMethods.create).toBeTruthy();
-        expect(passedParameters).toEqual(parametersToPass);
-
-        calledClientMethods.create = false;
-        restResult = 456;
-        parametersToPass = Object.assign({}, parametersToPass);
-        let entity = new Entity(restClient, {});
-        return entity.create(parametersToPass);
-      })
-      .then(response => {
-        expect(response).toBe(restResult);
-        expect(calledClientMethods.create).toBeTruthy();
-        expect(passedParameters).toEqual(parametersToPass);
-
-        done();
-      })
-      .catch(error => {
-        fail(error.stack);
-        done();
-      });
-  });
-
-  it('should allow deleting entities', done => {
-    restResult = 567;
-    return Entity.delete(restClient, 1, parametersToPass)
-      .then(response => {
-        expect(response).toBe(restResult);
-        expect(calledClientMethods.delete).toBeTruthy();
-        expect(passedParameters).toEqual(parametersToPass);
-
-        calledClientMethods.delete = false;
-        restResult = 678;
-        parametersToPass = Object.assign({}, parametersToPass);
-        let entity = new Entity(restClient, { id: 1 });
-        return entity.delete(parametersToPass);
-      })
-      .then(response => {
-        expect(response).toBe(restResult);
-        expect(calledClientMethods.delete).toBeTruthy();
-        expect(passedParameters).toEqual(parametersToPass);
-
-        done();
-      })
-      .catch(error => {
-        fail(error.stack);
-        done();
-      });
-  });
-
-  it('should allow listing of sub-resource entities', done => {
-    restResult = 789;
-    let entity = new Entity(restClient, {});
-    entity
-      .list(Entity, parametersToPass)
-      .then(response => {
-        expect(response).toBe(restResult);
-        expect(calledClientMethods.list).toBeTruthy();
-        expect(passedParameters).toEqual(parametersToPass);
-
-        done();
-      })
-      .catch(error => {
-        fail(error.stack);
-        done();
-      });
-  });
-
-  it('should allow fetching of single entities', done => {
-    restResult = 890;
-    let entity = new Entity(restClient, {});
-    entity
-      .get(Entity, 1, parametersToPass)
-      .then(response => {
-        expect(response).toBe(restResult);
-        expect(calledClientMethods.get).toBeTruthy();
-        expect(passedParameters).toEqual(parametersToPass);
-
-        done();
-      })
-      .catch(error => {
-        fail(error.stack);
-        done();
-      });
-  });
-
-  it('should allow patching entities', done => {
-    restResult = 901;
-    let entity = new Entity(restClient, { id: 1 });
-    entity
-      .patch({ id: 2, test: 'yay' }, parametersToPass)
-      .then(response => {
-        expect(response).toBe(restResult);
-        expect(calledClientMethods.patch).toBeTruthy();
-        expect(passedParameters).toEqual(parametersToPass);
-
-        expect(entity).toEqual(
-          new Entity(restClient, {
-            id: 2,
-            test: 'yay'
-          })
-        );
-
-        done();
-      })
-      .catch(error => {
-        fail(error.stack);
-        done();
-      });
-  });
-
-  it('should allow replacing entities', done => {
-    restResult = 12;
-    let entity = new Entity(restClient, {});
-    entity
-      .replace(parametersToPass)
-      .then(response => {
-        expect(response).toBe(restResult);
-        expect(calledClientMethods.replace).toBeTruthy();
-        expect(passedParameters).toEqual(parametersToPass);
-
-        done();
-      })
-      .catch(error => {
-        fail(error.stack);
-        done();
-      });
-  });
-
   describe('serialization', () => {
+    // eslint-disable-next-line no-unused-vars
     let serializeCalled = false;
 
     class TransformingEntity extends Entity {
@@ -324,128 +78,13 @@ describe('AbstractEntity', () => {
     });
 
     it('should deserialize entity data upon creation', () => {
-      let entity = new TransformingEntity(restClient, {
+      let entity = new TransformingEntity({
         test: 'tested',
         serialized: true
       });
       expect(Object.assign({}, entity)).toEqual({
         test: 'tested',
         dynamic: true
-      });
-    });
-
-    it(
-      'should create entities from deserialized data when using static ' +
-        'create()',
-      done => {
-        restClientCallbacks.create = data => {
-          expect(data).toEqual({
-            test: 'testing',
-            serialized: true
-          });
-        };
-        restResult = new TransformingEntity(restClient, {
-          test: 'testing',
-          serialized: true
-        });
-        TransformingEntity.create(restClient, {
-          test: 'testing',
-          dynamic: true
-        }).then(entity => {
-          expect(serializeCalled).toBeTruthy();
-          expect(Object.assign({}, entity)).toEqual({
-            test: 'testing',
-            dynamic: true
-          });
-          done();
-        });
-      }
-    );
-
-    it('should use deserialized entity data in the patch method', done => {
-      let entity = new TransformingEntity(restClient, {
-        test: 'testing',
-        testing: 'test',
-        serialized: true
-      });
-      let patchCalled = false;
-      restClientCallbacks.patch = data => {
-        patchCalled = true;
-        expect(data).toEqual({
-          test: 'tested',
-          test2: 1,
-          serialized: true
-        });
-      };
-      entity
-        .patch({
-          test: 'tested',
-          test2: 1,
-          onlyDynamic: true
-        })
-        .then(() => {
-          expect(patchCalled).toBeTruthy();
-          expect(Object.assign({}, entity)).toEqual({
-            test: 'tested',
-            testing: 'test',
-            dynamic: true,
-            onlyDynamic: true,
-            test2: 1
-          });
-          done();
-        });
-    });
-
-    it('should use deserialized entity data in the replace method', done => {
-      let entity = new TransformingEntity(restClient, {
-        test: 'testing',
-        testing: 'test',
-        serialized: true
-      });
-      let replaceCalled = false;
-      restClientCallbacks.replace = data => {
-        replaceCalled = true;
-        expect(data).toEqual({
-          test: 'tested',
-          testing: 'test',
-          serialized: true
-        });
-      };
-      entity.test = 'tested';
-      entity.replace().then(() => {
-        expect(replaceCalled).toBeTruthy();
-        expect(Object.assign({}, entity)).toEqual({
-          test: 'tested',
-          testing: 'test',
-          dynamic: true
-        });
-        done();
-      });
-    });
-
-    it('should use deserialized entity data in the dynamic create method', done => {
-      let entity = new TransformingEntity(restClient, {
-        test: 'testing',
-        testing: 'test',
-        serialized: true
-      });
-      let createCalled = false;
-      restClientCallbacks.create = data => {
-        createCalled = true;
-        expect(data).toEqual({
-          test: 'testing',
-          testing: 'test',
-          serialized: true
-        });
-      };
-      entity.create().then(() => {
-        expect(createCalled).toBeTruthy();
-        expect(Object.assign({}, entity)).toEqual({
-          test: 'testing',
-          testing: 'test',
-          dynamic: true
-        });
-        done();
       });
     });
 
@@ -459,7 +98,7 @@ describe('AbstractEntity', () => {
         }
       }
 
-      let entity = new DeclarativelyMappedEntity(restClient, {
+      let entity = new DeclarativelyMappedEntity({
         id: 1, // not mapped
         some_field: 'and here is the value',
         another: 'that is not renamed'
@@ -515,7 +154,7 @@ describe('AbstractEntity', () => {
         }
       }
 
-      let entity = new MappingEntity(restClient, {
+      let entity = new MappingEntity({
         _id: 123,
         foo: 'a',
         bar: 'b'
@@ -561,7 +200,7 @@ describe('AbstractEntity', () => {
         }
       }
 
-      let entity = new MappingEntity(restClient, {
+      let entity = new MappingEntity({
         _id: 123,
         foo: 'a',
         bar: 'b'
@@ -591,19 +230,19 @@ describe('AbstractEntity', () => {
         }
       }
 
-      let entity = new User(restClient, {
+      let entity = new User({
         id: 1,
         _session: { id: 'ABC' },
         otherSession: { id: 'DEF' },
         anotherSession: { id: 'GHI' }
       });
-      let templateEntity = new User(restClient, {});
+      let templateEntity = new User({});
       templateEntity.id = 1;
-      templateEntity.session = new Session(restClient, { id: 'ABC' });
-      templateEntity.otherSession = new Session(restClient, {
+      templateEntity.session = new Session({ id: 'ABC' });
+      templateEntity.otherSession = new Session({
         id: 'DEF'
       });
-      templateEntity.anotherSession = new Session(restClient, {
+      templateEntity.anotherSession = new Session({
         id: 'GHI'
       });
       expect(entity).toMatchObject(templateEntity);
@@ -630,7 +269,7 @@ describe('AbstractEntity', () => {
     it('should be mutable by default', () => {
       class Entity extends AbstractEntity {}
 
-      let entity = new Entity(restClient, { id: 1 });
+      let entity = new Entity({ id: 1 });
       entity.id = 2;
       entity.foo = 'bar';
       Object.defineProperty(entity, 'id', {
@@ -639,7 +278,7 @@ describe('AbstractEntity', () => {
     });
 
     it('should be deeply immutable if marked as such', () => {
-      let entity = new ImmutableEntity(restClient, {
+      let entity = new ImmutableEntity({
         id: 1,
         foo: {
           bar: {
@@ -654,7 +293,6 @@ describe('AbstractEntity', () => {
 
     it('should be able to clone an entity', () => {
       let entity = new ImmutableEntity(
-        restClient,
         {
           id: 1,
           text: 'is a text',
@@ -662,17 +300,17 @@ describe('AbstractEntity', () => {
           regexp: /a/
         },
         new ImmutableEntity(
-          restClient,
           {
             id: 'xy',
             isParent: true
           },
-          new ImmutableEntity(restClient, {
+          new ImmutableEntity({
             id: 'grand-parent',
             isGrandParent: true
           })
         )
       );
+
       let clone = entity.clone();
       expect(clone).not.toBe(entity);
       expect(clone).toEqual(entity);
@@ -690,7 +328,7 @@ describe('AbstractEntity', () => {
     });
 
     it('should enable creating modified clones of the entity', () => {
-      let entity = new ImmutableEntity(restClient, {
+      let entity = new ImmutableEntity({
         id: 1,
         foo: 'bar'
       });
@@ -704,106 +342,69 @@ describe('AbstractEntity', () => {
         baz: '000'
       });
     });
-
-    it('should be compatible with the patch() method', done => {
-      class ImmutableMockEntity extends Entity {
-        static get isImmutable() {
-          return true;
-        }
-      }
-
-      let entity = new ImmutableMockEntity(restClient, {
-        id: 1,
-        foo: 'bar'
-      });
-      restResult = {
-        id: 1,
-        foo: 'baz'
-      };
-      entity
-        .patch({ foo: 'baz' })
-        .then(patchedEntity => {
-          expect(entity.foo).toBe('bar');
-          expect(patchedEntity.foo).toBe('baz');
-          done();
-        })
-        .catch(error => {
-          fail(error);
-          done();
-        });
-      expect(entity.foo).toBe('bar');
-    });
   });
 
   describe('static properties', () => {
     it('should be possible to configure resourceName exactly once', () => {
-      testStaticProperty('resourceName', null, true, 'fooBar');
+      testStaticProperty(AbstractEntity, 'resourceName', null, true, 'fooBar');
     });
 
     it('should be possible to configure idFieldName exactly once', () => {
-      testStaticProperty('idFieldName', null, true, 'id');
+      testStaticProperty(AbstractEntity, 'idFieldName', null, true, 'id');
     });
 
     it('should be possible to configure inlineResponseBody exactly once', () => {
-      testStaticProperty('inlineResponseBody', false, false, true);
+      testStaticProperty(
+        AbstractEntity,
+        'inlineResponseBody',
+        false,
+        false,
+        true
+      );
     });
 
     it('should be possible to configure propTypes exactly once', () => {
-      testStaticProperty('propTypes', {}, false, { id: 'integer:>0' });
+      testStaticProperty(AbstractEntity, 'propTypes', {}, false, {
+        id: 'integer:>0'
+      });
     });
 
     it('should be possible to configure dataFieldMapping exactly once', () => {
-      testStaticProperty('dataFieldMapping', {}, false, { id: '_id' });
+      testStaticProperty(AbstractEntity, 'dataFieldMapping', {}, false, {
+        id: '_id'
+      });
     });
 
     it('should be possible to configure isImmutable exactly once', () => {
-      testStaticProperty('isImmutable', false, false, true);
+      testStaticProperty(AbstractEntity, 'isImmutable', false, false, true);
+    });
+
+    it('should be possible to configure idParameterName exactly once', () => {
+      testStaticProperty(
+        AbstractEntity,
+        'dataFieldMapping',
+        {},
+        false,
+        'itemId'
+      );
+    });
+
+    it('should be possible to configure embeds exactly once', () => {
+      testStaticProperty(AbstractEntity, 'isImmutable', false, false, {
+        id: '_id'
+      });
     });
 
     it(
       'should have all its private symbol properties marked as ' +
         'non-enumerable',
       () => {
-        let entity = new Entity(restClient, {});
+        let entity = new Entity({});
         for (let symbol of Object.getOwnPropertySymbols(entity)) {
           let descriptor = Object.getOwnPropertyDescriptor(entity, symbol);
           expect(descriptor.enumerable).toBe(false);
         }
       }
     );
-
-    function testStaticProperty(
-      propertyName,
-      defaultValue,
-      throwsError,
-      testingValue
-    ) {
-      class Entity1 extends AbstractEntity {}
-      class Entity2 extends AbstractEntity {}
-
-      if (throwsError) {
-        expect(() => {
-          return Entity1[propertyName];
-        }).toThrow();
-      } else {
-        expect(Entity1[propertyName]).toEqual(defaultValue);
-      }
-
-      Entity2[propertyName] = testingValue;
-      expect(Entity2[propertyName]).toBe(testingValue);
-
-      // The property must not be affected on other entity classes
-      if (throwsError) {
-        expect(() => {
-          return Entity1[propertyName];
-        }).toThrow();
-      } else {
-        expect(Entity1[propertyName]).toEqual(defaultValue);
-      }
-
-      expect(() => {
-        Entity2[propertyName] = testingValue;
-      }).toThrow();
-    }
   });
 });

--- a/packages/plugin-rest-client/src/__tests__/AbstractResourceSpec.js
+++ b/packages/plugin-rest-client/src/__tests__/AbstractResourceSpec.js
@@ -1,0 +1,208 @@
+import AbstractResource from '../AbstractResource';
+import AbstractEntity from '../AbstractEntity';
+import AbstractRestClient from '../AbstractRestClient';
+import { testStaticProperty } from './RestClientTestUtils';
+
+describe('AbstractResource', () => {
+  class Entity extends AbstractEntity {
+    static get resourceName() {
+      return 'foo';
+    }
+
+    static get idFieldName() {
+      return 'id';
+    }
+
+    static get inlineResponseBody() {
+      return true;
+    }
+  }
+
+  class Resource extends AbstractResource {
+    static get entityClass() {
+      return Entity;
+    }
+  }
+
+  class RestClient extends AbstractRestClient {
+    // eslint-disable-next-line no-unused-vars
+    list(resource, parameters = {}) {
+      return Promise.resolve();
+    }
+
+    // eslint-disable-next-line no-unused-vars
+    get(resource, id, parameters = {}) {
+      return Promise.resolve();
+    }
+
+    // eslint-disable-next-line no-unused-vars
+    create(resource, data, parameters = {}) {
+      return Promise.resolve();
+    }
+
+    // eslint-disable-next-line no-unused-vars
+    delete(resource, id, parameters = {}) {
+      return Promise.resolve();
+    }
+
+    // eslint-disable-next-line no-unused-vars
+    patch(resource, id, data, parameters = {}) {
+      return Promise.resolve();
+    }
+
+    // eslint-disable-next-line no-unused-vars
+    replace(resource, id, data, parameters = {}) {
+      return Promise.resolve();
+    }
+  }
+
+  let resource = null;
+  let restClient = null;
+  let parametersToPass = { key: 'value' };
+
+  beforeEach(() => {
+    restClient = new RestClient(null, null, null, [], []);
+    resource = new Resource(restClient);
+  });
+
+  describe('list', () => {
+    it('should call restClient.list method', done => {
+      spyOn(restClient, 'list').and.callThrough();
+
+      resource
+        .list(parametersToPass, {}, null)
+        .then(() => {
+          expect(restClient.list).toHaveBeenCalledWith(
+            resource.constructor.entityClass,
+            parametersToPass,
+            {},
+            null
+          );
+          done();
+        })
+        .catch(error => {
+          fail(error.stack);
+          done();
+        });
+    });
+  });
+
+  describe('get', () => {
+    it('should call restClient.get method', done => {
+      spyOn(restClient, 'get').and.callThrough();
+      const id = 24;
+
+      resource
+        .get(id, parametersToPass, {}, null)
+        .then(() => {
+          expect(restClient.get).toHaveBeenCalledWith(
+            resource.constructor.entityClass,
+            id,
+            parametersToPass,
+            {},
+            null
+          );
+          done();
+        })
+        .catch(error => {
+          fail(error.stack);
+          done();
+        });
+    });
+  });
+
+  describe('create', () => {
+    it('should call restClient.create method with data', done => {
+      spyOn(restClient, 'create').and.callThrough();
+      const data = {
+        id: 1,
+        foo: 'bar'
+      };
+
+      resource
+        .create(data, parametersToPass, {}, null)
+        .then(() => {
+          expect(restClient.create).toHaveBeenCalledWith(
+            resource.constructor.entityClass,
+            data,
+            parametersToPass,
+            {},
+            null
+          );
+          done();
+        })
+        .catch(error => {
+          fail(error.stack);
+          done();
+        });
+    });
+  });
+
+  describe('delete', () => {
+    it('should call restClient.delete method', done => {
+      spyOn(restClient, 'delete').and.callThrough();
+      const id = 24;
+
+      resource
+        .delete(id, parametersToPass, {}, null)
+        .then(() => {
+          expect(restClient.delete).toHaveBeenCalledWith(
+            resource.constructor.entityClass,
+            id,
+            parametersToPass,
+            {},
+            null
+          );
+          done();
+        })
+        .catch(error => {
+          fail(error.stack);
+          done();
+        });
+    });
+  });
+
+  describe('patch', () => {
+    it("should call restClient.patch method with entity's serialized data", done => {
+      spyOn(restClient, 'patch').and.callThrough();
+
+      const data = { id: 1, foo: 'bar' };
+      let newEntity = new Entity(data);
+      let serializedData = newEntity.$serialize(data);
+
+      resource
+        .patch(newEntity, data, parametersToPass, {})
+        .then(() => {
+          expect(restClient.patch).toHaveBeenCalledWith(
+            newEntity.constructor,
+            newEntity[Entity.idFieldName],
+            serializedData,
+            parametersToPass,
+            {}
+          );
+          done();
+        })
+        .catch(error => {
+          fail(error.stack);
+          done();
+        });
+    });
+  });
+
+  describe('static properties', () => {
+    it('should be possible to configure entityClass only once', () => {
+      testStaticProperty(AbstractResource, 'entityClass', null, true, Entity);
+    });
+
+    it(
+      'should have all its private symbol properties marked as ' +
+        'non-enumerable',
+      () => {
+        for (let symbol of Object.getOwnPropertySymbols(resource)) {
+          let descriptor = Object.getOwnPropertyDescriptor(resource, symbol);
+          expect(descriptor.enumerable).toBe(false);
+        }
+      }
+    );
+  });
+});

--- a/packages/plugin-rest-client/src/__tests__/AbstractRestClientSpec.js
+++ b/packages/plugin-rest-client/src/__tests__/AbstractRestClientSpec.js
@@ -840,11 +840,11 @@ describe('AbstractRestClient', () => {
           expect(response.request.resource).toBe(Entity);
           expect(response.body instanceof Array).toBeTruthy();
           expect(response.body).toEqual([
-            new Entity(restClient, {
+            new Entity({
               id: 1,
               stuff: 'yes'
             }),
-            new Entity(restClient, {
+            new Entity({
               id: 2,
               stuff: 'no'
             })
@@ -902,7 +902,7 @@ describe('AbstractRestClient', () => {
         []
       );
 
-      let parent = new Entity(restClient, {
+      let parent = new Entity({
         id: 'nope'
       });
 
@@ -912,7 +912,7 @@ describe('AbstractRestClient', () => {
           expect(response.request.resource).toBe(Entity);
           expect(response.body instanceof Entity).toBeTruthy();
           expect(response.body).toMatchObject(
-            new Entity(restClient, {
+            new Entity({
               id: 1,
               stuff: 'yes'
             })
@@ -985,7 +985,7 @@ describe('AbstractRestClient', () => {
         .then(response => {
           expect(response instanceof Entity).toBeTruthy();
           expect(response).toEqual(
-            new Entity(restClient, {
+            new Entity({
               id: 1,
               stuff: 'yes'
             })

--- a/packages/plugin-rest-client/src/__tests__/RestClientTestUtils.js
+++ b/packages/plugin-rest-client/src/__tests__/RestClientTestUtils.js
@@ -1,0 +1,34 @@
+export function testStaticProperty(
+  baseClass,
+  propertyName,
+  defaultValue,
+  throwsError,
+  testingValue
+) {
+  class Entity1 extends baseClass {}
+  class Entity2 extends baseClass {}
+
+  if (throwsError) {
+    expect(() => {
+      return Entity1[propertyName];
+    }).toThrow();
+  } else {
+    expect(Entity1[propertyName]).toEqual(defaultValue);
+  }
+
+  Entity2[propertyName] = testingValue;
+  expect(Entity2[propertyName]).toBe(testingValue);
+
+  // The property must not be affected on other entity classes
+  if (throwsError) {
+    expect(() => {
+      return Entity1[propertyName];
+    }).toThrow();
+  } else {
+    expect(Entity1[propertyName]).toEqual(defaultValue);
+  }
+
+  expect(() => {
+    Entity2[propertyName] = testingValue;
+  }).toThrow();
+}

--- a/packages/plugin-rest-client/src/main.js
+++ b/packages/plugin-rest-client/src/main.js
@@ -1,5 +1,6 @@
 import AbstractDataFieldMapper from './AbstractDataFieldMapper';
 import AbstractEntity from './AbstractEntity';
+import AbstractResource from './AbstractResource';
 import AbstractRestClient from './AbstractRestClient';
 import Configurator from './Configurator';
 import HttpMethod from './HttpMethod';
@@ -18,6 +19,7 @@ export default AbstractRestClient;
 export {
   AbstractDataFieldMapper,
   AbstractEntity,
+  AbstractResource,
   AbstractRestClient,
   Configurator,
   HttpMethod,


### PR DESCRIPTION
Addition of `AbstractResource` which now contains all rest API call methods that has been extracted from the `AbstractEntity`. 
This has removed dependency on REST API client on the Entity side but also removed all static REST API method calls from the Entity class which has to be handled through defining the resource/service (see above on how to use AbstractResource). Additionally all `AbstractEntity` instance REST API methods have been removed completely.