### PR TITLE
Reselect on props change

### DIFF
--- a/packages/plugin-select/src/select/__tests__/SelectSpec.js
+++ b/packages/plugin-select/src/select/__tests__/SelectSpec.js
@@ -1,5 +1,5 @@
-import { PageStateManager, Dispatcher } from '@ima/core';
-import { shallow } from 'enzyme';
+import { PageStateManager, Dispatcher, PageContext } from '@ima/core';
+import { shallow, mount } from 'enzyme';
 import React from 'react';
 import { toMockedInstance, setGlobalMockMethod } from 'to-mock';
 import forwardedSelect, {
@@ -99,6 +99,12 @@ describe('plugin-select:', () => {
       }
     }
 
+    const MockContextProvider = ({ children }) => (
+      <PageContext.Provider value={componentContext}>
+        {children}
+      </PageContext.Provider>
+    );
+
     it('should render component', () => {
       wrapper = shallow(React.createElement(Component, defaultProps), {
         context: componentContext
@@ -107,54 +113,55 @@ describe('plugin-select:', () => {
       expect(wrapper).toMatchSnapshot();
     });
 
-    it.skip('should render component with extraProps', () => {
+    it('should render component with extraProps', () => {
       let EnhancedComponent = select(...selectorMethods)(Component);
 
-      wrapper = shallow(React.createElement(EnhancedComponent, defaultProps), {
-        context: componentContext
+      wrapper = mount(React.createElement(EnhancedComponent, defaultProps), {
+        context: componentContext,
+        wrappingComponent: MockContextProvider
       });
 
       expect(wrapper).toMatchSnapshot();
     });
 
-    it.skip('should render component with extraProps modifies by ownProps', () => {
-      let EnhancedComponent = select(
-        ...selectorMethods,
-        selectorUsingProps
-      )(Component);
+    it('should render component with extraProps modifies by ownProps', () => {
+      let EnhancedComponent = select(...selectorMethods, selectorUsingProps)(
+        Component
+      );
 
-      wrapper = shallow(React.createElement(EnhancedComponent, defaultProps), {
-        context: componentContext
+      wrapper = mount(React.createElement(EnhancedComponent, defaultProps), {
+        context: componentContext,
+        wrappingComponent: MockContextProvider
       });
 
       expect(wrapper).toMatchSnapshot();
     });
 
-    it.skip('should add listener to dispatcher after mounting to DOM', () => {
+    it('should add listener to dispatcher after mounting to DOM', () => {
       let EnhancedComponent = select(...selectorMethods)(Component);
 
-      wrapper = shallow(React.createElement(EnhancedComponent, defaultProps), {
-        context: componentContext
+      wrapper = mount(React.createElement(EnhancedComponent, defaultProps), {
+        context: componentContext,
+        wrappingComponent: MockContextProvider
       });
-
-      wrapper.instance().componentDidMount();
 
       expect(componentContext.$Utils.$Dispatcher.listen).toHaveBeenCalled();
     });
 
-    it.skip('should remove listener to dispatcher before unmounting from DOM', () => {
+    it('should remove listener to dispatcher before unmounting from DOM', () => {
       let EnhancedComponent = select(...selectorMethods)(Component);
 
-      wrapper = shallow(React.createElement(EnhancedComponent, defaultProps), {
-        context: componentContext
+      wrapper = mount(React.createElement(EnhancedComponent, defaultProps), {
+        context: componentContext,
+        wrappingComponent: MockContextProvider
       });
 
-      wrapper.instance().componentWillUnmount();
+      wrapper.unmount();
 
       expect(componentContext.$Utils.$Dispatcher.unlisten).toHaveBeenCalled();
     });
 
-    it.skip('should render component with extraProps and own createStateSelector', () => {
+    it('should render component with extraProps and own createStateSelector', () => {
       setCreatorOfStateSelector((...selectors) => {
         return (state, context) => {
           return selectors.reduce((result, selector) => {
@@ -164,14 +171,15 @@ describe('plugin-select:', () => {
       });
       let EnhancedComponent = select(...selectorMethods)(Component);
 
-      wrapper = shallow(React.createElement(EnhancedComponent, defaultProps), {
-        context: componentContext
+      wrapper = mount(React.createElement(EnhancedComponent, defaultProps), {
+        context: componentContext,
+        wrappingComponent: MockContextProvider
       });
 
       expect(wrapper).toMatchSnapshot();
     });
 
-    it.skip('should render component with extraProps and own static methods', () => {
+    it('should render component with extraProps and own static methods', () => {
       setHoistStaticMethod((TargetComponent, Original) => {
         const keys = Object.getOwnPropertyNames(Original);
 
@@ -188,24 +196,12 @@ describe('plugin-select:', () => {
       });
       let EnhancedComponent = select(...selectorMethods)(Component);
 
-      wrapper = shallow(React.createElement(EnhancedComponent, defaultProps), {
-        context: componentContext
+      wrapper = mount(React.createElement(EnhancedComponent, defaultProps), {
+        context: componentContext,
+        wrappingComponent: MockContextProvider
       });
 
       expect(typeof EnhancedComponent.defaultProps === 'function').toBeTruthy();
-      expect(wrapper).toMatchSnapshot();
-    });
-
-    it.skip('should remove forwardedRef prop (replaces it with ref)', () => {
-      let EnhancedComponent = select(...selectorMethods)(Component);
-      let props = Object.assign({}, defaultProps, {
-        forwardedRef: React.createRef()
-      });
-
-      wrapper = shallow(React.createElement(EnhancedComponent, props), {
-        context: componentContext
-      });
-
       expect(wrapper).toMatchSnapshot();
     });
 

--- a/packages/plugin-select/src/select/__tests__/__snapshots__/SelectSpec.js.snap
+++ b/packages/plugin-select/src/select/__tests__/__snapshots__/SelectSpec.js.snap
@@ -8,7 +8,7 @@ Object {
 `;
 
 exports[`plugin-select: select should forward ref 1`] = `
-<SelectState
+<withContext(Component)
   forwardedRef={
     Object {
       "current": null,
@@ -19,15 +19,6 @@ exports[`plugin-select: select should forward ref 1`] = `
 />
 `;
 
-exports[`plugin-select: select should remove forwardedRef prop (replaces it with ref) 1`] = `
-<Component
-  height={60}
-  multiplier={0.5}
-  props="props"
-  width={90}
-/>
-`;
-
 exports[`plugin-select: select should render component 1`] = `
 <h1>
   text
@@ -35,37 +26,173 @@ exports[`plugin-select: select should render component 1`] = `
 `;
 
 exports[`plugin-select: select should render component with extraProps 1`] = `
-<Component
-  height={60}
+<withContext(Component)
   multiplier={0.5}
   props="props"
-  width={90}
-/>
+>
+  <SelectState
+    context={
+      Object {
+        "$Utils": Object {
+          "$Dispatcher": Mock {},
+          "$PageStateManager": Mock {
+            "getState": [Function],
+          },
+        },
+      }
+    }
+    multiplier={0.5}
+    props="props"
+  >
+    <Component
+      context={
+        Object {
+          "$Utils": Object {
+            "$Dispatcher": Mock {},
+            "$PageStateManager": Mock {
+              "getState": [Function],
+            },
+          },
+        }
+      }
+      height={60}
+      multiplier={0.5}
+      props="props"
+      width={90}
+    >
+      <h1>
+        text
+      </h1>
+    </Component>
+  </SelectState>
+</withContext(Component)>
 `;
 
 exports[`plugin-select: select should render component with extraProps and own createStateSelector 1`] = `
-<Component
-  height={60}
+<withContext(Component)
   multiplier={0.5}
   props="props"
-  width={90}
-/>
+>
+  <SelectState
+    context={
+      Object {
+        "$Utils": Object {
+          "$Dispatcher": Mock {},
+          "$PageStateManager": Mock {
+            "getState": [Function],
+          },
+        },
+      }
+    }
+    multiplier={0.5}
+    props="props"
+  >
+    <Component
+      context={
+        Object {
+          "$Utils": Object {
+            "$Dispatcher": Mock {},
+            "$PageStateManager": Mock {
+              "getState": [Function],
+            },
+          },
+        }
+      }
+      height={60}
+      multiplier={0.5}
+      props="props"
+      width={90}
+    >
+      <h1>
+        text
+      </h1>
+    </Component>
+  </SelectState>
+</withContext(Component)>
 `;
 
 exports[`plugin-select: select should render component with extraProps and own static methods 1`] = `
-<Component
-  height={60}
+<withContext(Component)
   multiplier={0.5}
   props="props"
-  width={90}
-/>
+>
+  <SelectState
+    context={
+      Object {
+        "$Utils": Object {
+          "$Dispatcher": Mock {},
+          "$PageStateManager": Mock {
+            "getState": [Function],
+          },
+        },
+      }
+    }
+    multiplier={0.5}
+    props="props"
+  >
+    <Component
+      context={
+        Object {
+          "$Utils": Object {
+            "$Dispatcher": Mock {},
+            "$PageStateManager": Mock {
+              "getState": [Function],
+            },
+          },
+        }
+      }
+      height={60}
+      multiplier={0.5}
+      props="props"
+      width={90}
+    >
+      <h1>
+        text
+      </h1>
+    </Component>
+  </SelectState>
+</withContext(Component)>
 `;
 
 exports[`plugin-select: select should render component with extraProps modifies by ownProps 1`] = `
-<Component
-  height={30}
+<withContext(Component)
   multiplier={0.5}
   props="props"
-  width={45}
-/>
+>
+  <SelectState
+    context={
+      Object {
+        "$Utils": Object {
+          "$Dispatcher": Mock {},
+          "$PageStateManager": Mock {
+            "getState": [Function],
+          },
+        },
+      }
+    }
+    multiplier={0.5}
+    props="props"
+  >
+    <Component
+      context={
+        Object {
+          "$Utils": Object {
+            "$Dispatcher": Mock {},
+            "$PageStateManager": Mock {
+              "getState": [Function],
+            },
+          },
+        }
+      }
+      height={30}
+      multiplier={0.5}
+      props="props"
+      width={45}
+    >
+      <h1>
+        text
+      </h1>
+    </Component>
+  </SelectState>
+</withContext(Component)>
 `;

--- a/packages/plugin-select/src/select/__tests__/__snapshots__/SelectSpec.js.snap
+++ b/packages/plugin-select/src/select/__tests__/__snapshots__/SelectSpec.js.snap
@@ -31,7 +31,7 @@ exports[`plugin-select: select should render component with extraProps 1`] = `
   props="props"
 >
   <SelectState
-    context={
+    $context={
       Object {
         "$Utils": Object {
           "$Dispatcher": Mock {},
@@ -45,7 +45,7 @@ exports[`plugin-select: select should render component with extraProps 1`] = `
     props="props"
   >
     <Component
-      context={
+      $context={
         Object {
           "$Utils": Object {
             "$Dispatcher": Mock {},
@@ -74,7 +74,7 @@ exports[`plugin-select: select should render component with extraProps and own c
   props="props"
 >
   <SelectState
-    context={
+    $context={
       Object {
         "$Utils": Object {
           "$Dispatcher": Mock {},
@@ -88,7 +88,7 @@ exports[`plugin-select: select should render component with extraProps and own c
     props="props"
   >
     <Component
-      context={
+      $context={
         Object {
           "$Utils": Object {
             "$Dispatcher": Mock {},
@@ -117,7 +117,7 @@ exports[`plugin-select: select should render component with extraProps and own s
   props="props"
 >
   <SelectState
-    context={
+    $context={
       Object {
         "$Utils": Object {
           "$Dispatcher": Mock {},
@@ -131,7 +131,7 @@ exports[`plugin-select: select should render component with extraProps and own s
     props="props"
   >
     <Component
-      context={
+      $context={
         Object {
           "$Utils": Object {
             "$Dispatcher": Mock {},
@@ -160,7 +160,7 @@ exports[`plugin-select: select should render component with extraProps modifies 
   props="props"
 >
   <SelectState
-    context={
+    $context={
       Object {
         "$Utils": Object {
           "$Dispatcher": Mock {},
@@ -174,7 +174,7 @@ exports[`plugin-select: select should render component with extraProps modifies 
     props="props"
   >
     <Component
-      context={
+      $context={
         Object {
           "$Utils": Object {
             "$Dispatcher": Mock {},

--- a/packages/plugin-select/src/select/select.jsx
+++ b/packages/plugin-select/src/select/select.jsx
@@ -51,6 +51,12 @@ export function select(...selectors) {
         );
       }
 
+      constructor(props, context) {
+        super(props, context);
+
+        this.state = SelectState.resolveNewState(props);
+      }
+
       componentDidMount() {
         this.utils.$Dispatcher.listen(
           StateEvents.AFTER_CHANGE_STATE,

--- a/packages/plugin-select/src/select/select.jsx
+++ b/packages/plugin-select/src/select/select.jsx
@@ -22,9 +22,8 @@ export function setHoistStaticMethod(method) {
 }
 
 export function select(...selectors) {
-  const stateSelector = creatorOfStateSelector(...selectors);
-
   return Component => {
+    const stateSelector = creatorOfStateSelector(...selectors);
     const componentName = Component.displayName || Component.name;
 
     const WithContext = props => {

--- a/packages/plugin-select/src/select/select.jsx
+++ b/packages/plugin-select/src/select/select.jsx
@@ -29,7 +29,7 @@ export function select(...selectors) {
     const WithContext = props => {
       const context = useContext(PageContext);
 
-      return <SelectState {...props} context={context} />;
+      return <SelectState {...props} $context={context} />;
     };
 
     WithContext.displayName = `withContext(${componentName})`;
@@ -40,12 +40,12 @@ export function select(...selectors) {
       }
 
       static resolveNewState(props) {
-        const { context, ...restProps } = props;
-        const utils = getUtils(restProps, context);
+        const { $context, ...restProps } = props;
+        const utils = getUtils(restProps, $context);
 
         return stateSelector(
           utils.$PageStateManager.getState(),
-          context,
+          $context,
           restProps
         );
       }

--- a/packages/plugin-select/src/select/select.jsx
+++ b/packages/plugin-select/src/select/select.jsx
@@ -5,7 +5,7 @@ import {
   getUtils
 } from '@ima/core';
 import hoistNonReactStaticMethod from 'hoist-non-react-statics';
-import React from 'react';
+import React, { useContext } from 'react';
 import { createSelector } from 'reselect';
 
 let creatorOfStateSelector = createStateSelector;
@@ -27,11 +27,11 @@ export function select(...selectors) {
   return Component => {
     const componentName = Component.displayName || Component.name;
 
-    const WithContext = props => (
-      <PageContext.Consumer>
-        {context => <SelectState {...props} context={context} />}
-      </PageContext.Consumer>
-    );
+    const WithContext = props => {
+      const context = useContext(PageContext);
+
+      return <SelectState {...props} context={context} />;
+    };
 
     WithContext.displayName = `withContext(${componentName})`;
 


### PR DESCRIPTION
Re-run selectors when "own" props change. This is for cases where data coming from selectors depends on given props.

- Solved by implementing `static getDerivedStateFromProps` which runs selectors on props change. This eludes using `componentDidUpdate` that would need to implement deep-equal to avoid infinity loop and would re-render component each time.

- Because `getDerivedStateFromProps` is static and we need `PageState` and `PageContext` in selectors the `SelectState` component is wrapped in `PageContext.Consumer` and the context is passed via props.