### PR TITLE
feat: 🎸 Create function to chain HOC

### DIFF
--- a/packages/plugin-select/src/select/select.jsx
+++ b/packages/plugin-select/src/select/select.jsx
@@ -21,6 +21,26 @@ export function setHoistStaticMethod(method) {
   hoistStaticMethod = method;
 }
 
+export function chainHOC(
+  Original,
+  generators = [],
+  staticHoistingFunction = hoistNonReactStaticMethod
+) {
+  const TargetComponent = generators.reduce((PrevComponent, generator) => {
+    if (typeof generator === 'function') {
+      return generator(PrevComponent);
+    } else if (
+      typeof generator.method === 'function' &&
+      Array.isArray(generator.params)
+    ) {
+      return generator.method(PrevComponent, ...generator.params);
+    }
+    return PrevComponent;
+  }, Original);
+
+  return staticHoistingFunction(TargetComponent, Original);
+}
+
 export function select(...selectors) {
   return Component => {
     const stateSelector = creatorOfStateSelector(...selectors);


### PR DESCRIPTION
Create new function `chainHOC` that hoists static methods from the
original component to the final component. This way you don't have to
depend on each HOC generator to properly hoist static methods by itself.