### PR TITLE
fix: 🐛 Enable testing localized code

### DIFF
--- a/packages/plugin-testing-integration/package.json
+++ b/packages/plugin-testing-integration/package.json
@@ -48,6 +48,7 @@
     "@ima/helpers": "^17.4.0",
     "globby": "^11.0.0",
     "jsdom": "^16.2.1",
+    "messageformat": "^2.3.0",
     "to-aop": "^0.3.5"
   },
   "peerDependencies": {

--- a/packages/plugin-testing-integration/src/app.js
+++ b/packages/plugin-testing-integration/src/app.js
@@ -201,7 +201,7 @@ async function initImaApp(bootConfigMethods = {}) {
 
   vendors = build.vendors;
 
-  global.$IMA.i18n = _generateDictionary(build.languages);
+  global.$IMA.i18n = _generateDictionary(build.languages, config.locale);
 
   defaultBootConfigMethods = requireFromProject(
     config.appMainPath

--- a/packages/plugin-testing-integration/src/app.js
+++ b/packages/plugin-testing-integration/src/app.js
@@ -11,6 +11,9 @@ import { JSDOM } from 'jsdom';
 import { requireFromProject, loadFiles } from './helpers';
 import { getConfig } from './configuration';
 import { getBootConfigExtensions } from './bootConfigExtensions';
+import MessageFormat from 'messageformat';
+import globby from 'globby';
+import path from 'path';
 
 const setIntervalNative = setInterval;
 const setTimeoutNative = setTimeout;
@@ -118,6 +121,35 @@ async function initImaApp(bootConfigMethods = {}) {
     global.$IMA.$App = {};
   }
 
+  function _generateDictionary(languages, locale = 'en') {
+    // FIXME allow setting locale through config
+    const mf = new MessageFormat(locale);
+    const dictionaries = {};
+    const langFileGlobs = languages[locale];
+    globby.sync(langFileGlobs).forEach(file => {
+      try {
+        const filename = path
+          .basename(file)
+          .replace(locale.toUpperCase() + path.extname(file), '');
+
+        const dictJson = requireFromProject(file);
+        const dict = {};
+        Object.keys(dictJson).forEach(key => {
+          const message = dictJson[key];
+          dict[key] = mf.compile(message);
+        });
+
+        dictionaries[filename] = dict;
+      } catch (e) {
+        console.error(
+          `Tried to load dictionary JSON at path "${file}", but recieved following error.`
+        );
+        console.error(e);
+      }
+    });
+    return dictionaries;
+  }
+
   function _installTimerWrappers() {
     global.setInterval = (...args) => {
       let timer = setIntervalNative(...args);
@@ -168,6 +200,9 @@ async function initImaApp(bootConfigMethods = {}) {
   const { js, ...build } = requireFromProject(config.appBuildPath);
 
   vendors = build.vendors;
+
+  global.$IMA.i18n = _generateDictionary(build.languages);
+
   defaultBootConfigMethods = requireFromProject(
     config.appMainPath
   ).getInitialAppConfigFunctions();

--- a/packages/plugin-testing-integration/src/configuration.js
+++ b/packages/plugin-testing-integration/src/configuration.js
@@ -5,6 +5,7 @@ let configuration = {
   protocol: 'https:',
   host: 'imajs.io',
   environment: 'test',
+  locale: 'en',
   TestPageRenderer: null,
   initSettings: () => {},
   initBindApp: () => {},


### PR DESCRIPTION
Currently it's not possible to test code using `$Dictionary` (e.g.
components with calls to `this.localize()`), as the dictionary is
generated during build by `gulp-tasks`. The new function
`_generateDictionary` generates this dictionary during init.