### PR TITLE
fix: removed error check for containerSelector property

### DIFF
--- a/packages/plugin-merkur/src/MerkurResource.js
+++ b/packages/plugin-merkur/src/MerkurResource.js
@@ -31,12 +31,6 @@ export default class MerkurResource {
    * @return {Promise<Response>} response
    */
   async get(url, data, options = {}) {
-    if (!data.containerSelector) {
-      throw new Error(
-        'The containerSelector property must be set in data argument.'
-      );
-    }
-
     let cloneData = Object.assign({}, data);
     const { containerSelector, slots = {} } = cloneData;
 


### PR DESCRIPTION
Since Merkur 0.24 sending container selector with request is deprecated, so this check has been
removed.