### PR TITLE
ga-consent Add `ad_personalization` to denied consent settings.

### DIFF
--- a/.changeset/empty-snails-share.md
+++ b/.changeset/empty-snails-share.md
@@ -1,0 +1,9 @@
+---
+"@ima/plugin-analytic-google": patch
+---
+
+Missing consent setting
+
+- **What?** Adds a missing consent setting.
+- **Why?** We need to deny it.
+- **How?** Nothing.

--- a/packages/plugin-analytic-google/src/main.ts
+++ b/packages/plugin-analytic-google/src/main.ts
@@ -12,12 +12,13 @@ pluginLoader.register('@ima/plugin-analytic-google', () => ({
         analytic: {
           google4: {
             consentSettings: {
+              ad_personalization: 'denied',
               ad_storage: 'denied',
+              ad_user_data: 'denied',
               analytics_storage: 'denied',
               functionality_storage: 'denied',
               personalization_storage: 'denied',
               security_storage: 'denied',
-              ad_user_data: 'denied',
             },
             service: 'G-XXXXXXXXXX',
             waitForUpdateTimeout: 5000,


### PR DESCRIPTION
Add missing consent option to default.