### PR TITLE
plugin-select-readme Describe how to mock a selector return value

### DIFF
--- a/packages/plugin-select/README.md
+++ b/packages/plugin-select/README.md
@@ -140,11 +140,13 @@ const context = {
     },
 };
 
+//..
+
 const wrapper = mount(
             React.createElement(
                 PageContext.Provider,
                 { value: context },
-                React.createElement(MyComponent, { permissions })
+                React.createElement(MyComponent, props)
             )
         );
 

--- a/packages/plugin-select/README.md
+++ b/packages/plugin-select/README.md
@@ -118,6 +118,35 @@ The first one is setCreatorOfStateSelector where you can redefine your own selec
 
 The second one is setHoistStaticMethod where you can override [hoist-non-react-statics](https://www.npmjs.com/package/hoist-non-react-statics) module like [example](https://github.com/seznam/IMA.js-plugins/blob/master/packages/plugin-select/src/select/__tests__/SelectSpec.js#L155).
 
+## How to mock in tests
+
+To test a component wrapped in `select`, mock `context.$Utils.$PermissionValidator.getState()` and `context.$Utils.$Dispatcher.listen()`. 
+
+Example:
+
+```js
+const context = {
+    $Utils: {
+        $PermissionValidator: {
+            hasPermission: hasPermissionMock,
+        },
+        $PageStateManager: {
+            getState: jest.fn(),
+        },
+        $Dispatcher: {
+			listen: () => {}
+		},
+    },
+};
+
+const setup = setupMountFactory(AuthedComponent, context);
+const wrapper = setup(props);
+
+context.$Utils.$PageStateManager.getState.mockReturnValue({foo: 'bar'})
+
+```
+
+
 ## IMA.js
 
 The [IMA.js](https://imajs.io) is an application development stack for developing

--- a/packages/plugin-select/README.md
+++ b/packages/plugin-select/README.md
@@ -120,16 +120,17 @@ The second one is setHoistStaticMethod where you can override [hoist-non-react-s
 
 ## How to mock in tests
 
-To test a component wrapped in `select`, mock `context.$Utils.$PermissionValidator.getState()` and `context.$Utils.$Dispatcher.listen()`. 
+To test a component wrapped in `select`, mock `context.$Utils.$PageStateManager.getState()` and `context.$Utils.$Dispatcher.listen()`. 
 
 Example:
 
 ```js
+
+import { mount } from 'enzyme';
+import { PageContext } from '@ima/react-page-renderer';
+
 const context = {
     $Utils: {
-        $PermissionValidator: {
-            hasPermission: hasPermissionMock,
-        },
         $PageStateManager: {
             getState: jest.fn(),
         },
@@ -139,8 +140,13 @@ const context = {
     },
 };
 
-const setup = setupMountFactory(AuthedComponent, context);
-const wrapper = setup(props);
+const wrapper = mount(
+            React.createElement(
+                PageContext.Provider,
+                { value: context },
+                React.createElement(MyComponent, { permissions })
+            )
+        );
 
 context.$Utils.$PageStateManager.getState.mockReturnValue({foo: 'bar'})
 


### PR DESCRIPTION
Add instructions for mocking dependencies of `select` and `useSelect`, so components can be tested.