### PR TITLE
Refactor `GoogleAnalytics4` types

### DIFF
--- a/.changeset/big-lies-dream.md
+++ b/.changeset/big-lies-dream.md
@@ -1,0 +1,9 @@
+---
+"@ima/plugin-analytic-google": minor
+---
+
+Refactor types
+
+- **What?** Export new `PageViewData` type, change `AnalyticGoogleSettings` to an interface.
+- **Why?** To enable overloading in child classes.
+- **How?** Nothing.

--- a/packages/plugin-analytic-google/src/GoogleAnalytics4.ts
+++ b/packages/plugin-analytic-google/src/GoogleAnalytics4.ts
@@ -9,11 +9,20 @@ type ConsentSettings = {
   personalization_storage?: 'denied' | 'granted';
 };
 
-export type AnalyticGoogleSettings = {
+export interface AnalyticGoogleSettings {
   consentSettings?: ConsentSettings;
   service: string;
   waitForUpdateTimeout?: number;
-};
+}
+
+export interface PageViewData {
+  page_location: string;
+  page_path: string;
+  page_referrer: string;
+  page_route: string;
+  page_status?: string;
+  page_title: string;
+}
 
 /**
  * Google analytic 4 class
@@ -149,10 +158,10 @@ export class GoogleAnalytics4 extends AbstractAnalytic {
   /**
    * Returns page view data derived from pageData param.
    */
-  _getPageViewData(pageData: Record<string, any>) {
+  _getPageViewData(pageData: Record<string, any>): PageViewData {
     const page_location = this._window?.getUrl();
     const clientDocument = this._window?.getDocument();
-    const page_referrer = this.#referrer || clientDocument?.referrer;
+    const page_referrer = this.#referrer || clientDocument?.referrer || '';
 
     return {
       page_path: pageData.path,

--- a/packages/plugin-analytic-google/src/main.ts
+++ b/packages/plugin-analytic-google/src/main.ts
@@ -1,9 +1,6 @@
 import { pluginLoader } from '@ima/core';
 
-import {
-  GoogleAnalytics4,
-  type AnalyticGoogleSettings,
-} from './GoogleAnalytics4';
+import { GoogleAnalytics4 } from './GoogleAnalytics4';
 
 pluginLoader.register('@ima/plugin-analytic-google', () => ({
   initSettings: () => ({
@@ -30,4 +27,8 @@ pluginLoader.register('@ima/plugin-analytic-google', () => ({
 }));
 
 export type { PluginAnalyticGoogleSettings } from './types';
-export { GoogleAnalytics4, type AnalyticGoogleSettings };
+export { GoogleAnalytics4 };
+export {
+  type PageViewData,
+  type AnalyticGoogleSettings,
+} from './GoogleAnalytics4';


### PR DESCRIPTION
Export new `PageViewData` type and change `AnalyticGoogleSettings` to an interface, to enable extending the class in TS. 