### PR TITLE
blogy-2061 Allowed partial use of HttpAgentRequestOptions in HttpClientRequestOptions

### DIFF
--- a/packages/plugin-http-client/src/HttpClient.ts
+++ b/packages/plugin-http-client/src/HttpClient.ts
@@ -18,7 +18,7 @@ export const OPTION_TRANSFORM_PROCESSORS = 'transformProcessors';
 
 export type HttpClientRequestOptions = {
   [OPTION_TRANSFORM_PROCESSORS]?: (processor: Processor[]) => Processor[];
-} & HttpAgentRequestOptions;
+} & Partial<HttpAgentRequestOptions>;
 
 export type HttpClientRequestMethod =
   | 'get'


### PR DESCRIPTION
The create() method (and another in AbstractRecource) expected a parameter of type HttpClientRequestOptions, but passing only fetchOptions caused an error - TypeScript required all mandatory fields from HttpAgentRequestOptions (timeout, ttl atd.).

TS-error: Argument of type '{ fetchOptions: { credentials: "include"; }; }' is not assignable to parameter of type 'HttpClientRequestOptions'.
  Type '{ fetchOptions: { credentials: "include"; }; }' is missing the following properties from type 'HttpAgentRequestOptions': timeout, ttl, repeatRequest, cache

The issue was solved by wrapping HttpAgentRequestOptions in Partial, since in many cases it is sufficient to use the default values. This allows to pass only necessary options (e.g. fetchOptions).